### PR TITLE
feat: add web approval UI with multi-channel broadcast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,24 @@
 {
-  "name": "lucifer",
+  "name": "lucifer-gate",
   "version": "0.1.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lucifer",
+      "name": "lucifer-gate",
       "version": "0.1.0-alpha.1",
+      "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.8.0",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.3.2",
         "pino": "^10.3.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "telegraf": "^4.16.3"
+      },
+      "bin": {
+        "lucifer-gate": "dist/server/cli.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -39,6 +44,9 @@
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4",
         "vitest": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3554,6 +3562,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-copy": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
@@ -4106,6 +4132,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "better-sqlite3": "^12.8.0",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.3.2",
     "pino": "^10.3.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/server/src/create_app.ts
+++ b/server/src/create_app.ts
@@ -5,7 +5,7 @@ import { getServerConfig } from './domains/platform-api/config/server_config.js'
 import { registerHealthRoutes } from './domains/platform-api/api/register_health_routes.js'
 import { createRuntimeMetadataRepository } from './domains/platform-api/repository/runtime_metadata_repository.js'
 import { createHealthReportService } from './domains/platform-api/service/create_health_report.js'
-import { loadGatewayConfig } from './domains/command-gateway/config/gateway_config.js'
+import { loadGatewayConfig, getAdminSecret } from './domains/command-gateway/config/gateway_config.js'
 import { getDatabase, closeDatabase } from './domains/command-gateway/repository/database.js'
 import { createApprovalStore } from './domains/command-gateway/repository/approval_store.js'
 import { createAuditLog } from './domains/command-gateway/repository/audit_log.js'
@@ -18,7 +18,6 @@ import { createAutoApproveChannel } from './domains/command-gateway/service/auto
 import { createWebApprovalChannel } from './domains/command-gateway/service/web_approval_channel.js'
 import { createMultiApprovalChannel } from './domains/command-gateway/service/multi_approval_channel.js'
 import { registerApprovalRoutes } from './domains/command-gateway/api/register_approval_routes.js'
-import { getAdminSecret } from './domains/command-gateway/config/gateway_config.js'
 import type { ApprovalChannel } from './domains/command-gateway/types/command_types.js'
 import { createChildLogger } from './lib/logger.js'
 
@@ -27,6 +26,46 @@ const log = createChildLogger('app')
 export interface CreateAppOptions {
   configPath?: string
   autoApprove?: boolean
+}
+
+interface GatewayDeps {
+  app: ReturnType<typeof express>
+  pendingStore: ReturnType<typeof createPendingRequestStore>
+  approvalStore: ReturnType<typeof createApprovalStore>
+  auditLog: ReturnType<typeof createAuditLog>
+  gatewayConfig: ReturnType<typeof loadGatewayConfig>
+}
+
+function initApprovalChannel(deps: GatewayDeps, autoApprove: boolean): ApprovalChannel {
+  if (autoApprove) {
+    return createAutoApproveChannel()
+  }
+
+  const channels: ApprovalChannel[] = []
+  const { app, pendingStore, approvalStore, auditLog, gatewayConfig } = deps
+
+  const telegramToken = process.env.LUCIFER_TELEGRAM_TOKEN
+  const chatId = gatewayConfig.telegramChatId ?? process.env.LUCIFER_TELEGRAM_CHAT_ID
+  if (telegramToken && chatId) {
+    channels.push(createTelegramApprovalChannel(telegramToken, chatId, pendingStore, approvalStore, auditLog))
+  }
+
+  const adminSecret = getAdminSecret()
+  if (adminSecret) {
+    const webChannel = createWebApprovalChannel()
+    channels.push(webChannel)
+    registerApprovalRoutes({ router: app, adminSecret, webChannel, approvalStore, auditLog })
+    log.info('Web approval UI enabled at /admin/approvals')
+  }
+
+  if (channels.length === 0) {
+    throw new Error(
+      'No approval channels configured. Set LUCIFER_TELEGRAM_TOKEN + LUCIFER_TELEGRAM_CHAT_ID for Telegram, ' +
+      'or LUCIFER_ADMIN_SECRET for web UI, or use --auto-approve for development.',
+    )
+  }
+
+  return channels.length === 1 ? channels[0] : createMultiApprovalChannel(channels)
 }
 
 export function createApp(options: CreateAppOptions = {}) {
@@ -64,36 +103,10 @@ export function createApp(options: CreateAppOptions = {}) {
     const commandRulesStore = createCommandRulesStore(commandRulesPath)
     const pendingStore = createPendingRequestStore()
 
-    if (options.autoApprove) {
-      approvalChannel = createAutoApproveChannel()
-    } else {
-      const channels: ApprovalChannel[] = []
-
-      // Telegram channel (if configured)
-      const telegramToken = process.env.LUCIFER_TELEGRAM_TOKEN
-      const chatId = gatewayConfig.telegramChatId ?? process.env.LUCIFER_TELEGRAM_CHAT_ID
-      if (telegramToken && chatId) {
-        channels.push(createTelegramApprovalChannel(telegramToken, chatId, pendingStore, approvalStore, auditLog))
-      }
-
-      // Web approval channel (if admin secret is set)
-      const adminSecret = getAdminSecret()
-      if (adminSecret) {
-        const webChannel = createWebApprovalChannel()
-        channels.push(webChannel)
-        registerApprovalRoutes({ router: app, adminSecret, webChannel, approvalStore, auditLog })
-        log.info('Web approval UI enabled at /admin/approvals')
-      }
-
-      if (channels.length === 0) {
-        throw new Error(
-          'No approval channels configured. Set LUCIFER_TELEGRAM_TOKEN + LUCIFER_TELEGRAM_CHAT_ID for Telegram, ' +
-          'or LUCIFER_ADMIN_SECRET for web UI, or use --auto-approve for development.',
-        )
-      }
-
-      approvalChannel = channels.length === 1 ? channels[0] : createMultiApprovalChannel(channels)
-    }
+    approvalChannel = initApprovalChannel(
+      { app, pendingStore, approvalStore, auditLog, gatewayConfig },
+      options.autoApprove ?? false,
+    )
 
     registerExecuteRoutes({
       router: app, config: gatewayConfig, apiKeyStore, commandRulesStore,

--- a/server/src/create_app.ts
+++ b/server/src/create_app.ts
@@ -5,7 +5,7 @@ import { getServerConfig } from './domains/platform-api/config/server_config.js'
 import { registerHealthRoutes } from './domains/platform-api/api/register_health_routes.js'
 import { createRuntimeMetadataRepository } from './domains/platform-api/repository/runtime_metadata_repository.js'
 import { createHealthReportService } from './domains/platform-api/service/create_health_report.js'
-import { loadGatewayConfig, getTelegramToken } from './domains/command-gateway/config/gateway_config.js'
+import { loadGatewayConfig } from './domains/command-gateway/config/gateway_config.js'
 import { getDatabase, closeDatabase } from './domains/command-gateway/repository/database.js'
 import { createApprovalStore } from './domains/command-gateway/repository/approval_store.js'
 import { createAuditLog } from './domains/command-gateway/repository/audit_log.js'
@@ -15,6 +15,10 @@ import { createPendingRequestStore } from './domains/command-gateway/repository/
 import { registerExecuteRoutes } from './domains/command-gateway/api/register_execute_routes.js'
 import { createTelegramApprovalChannel } from './domains/command-gateway/service/request_telegram_approval.js'
 import { createAutoApproveChannel } from './domains/command-gateway/service/auto_approve_channel.js'
+import { createWebApprovalChannel } from './domains/command-gateway/service/web_approval_channel.js'
+import { createMultiApprovalChannel } from './domains/command-gateway/service/multi_approval_channel.js'
+import { registerApprovalRoutes } from './domains/command-gateway/api/register_approval_routes.js'
+import { getAdminSecret } from './domains/command-gateway/config/gateway_config.js'
 import type { ApprovalChannel } from './domains/command-gateway/types/command_types.js'
 import { createChildLogger } from './lib/logger.js'
 
@@ -63,14 +67,32 @@ export function createApp(options: CreateAppOptions = {}) {
     if (options.autoApprove) {
       approvalChannel = createAutoApproveChannel()
     } else {
-      const token = getTelegramToken()
+      const channels: ApprovalChannel[] = []
+
+      // Telegram channel (if configured)
+      const telegramToken = process.env.LUCIFER_TELEGRAM_TOKEN
       const chatId = gatewayConfig.telegramChatId ?? process.env.LUCIFER_TELEGRAM_CHAT_ID
-      if (!chatId) {
+      if (telegramToken && chatId) {
+        channels.push(createTelegramApprovalChannel(telegramToken, chatId, pendingStore, approvalStore, auditLog))
+      }
+
+      // Web approval channel (if admin secret is set)
+      const adminSecret = getAdminSecret()
+      if (adminSecret) {
+        const webChannel = createWebApprovalChannel()
+        channels.push(webChannel)
+        registerApprovalRoutes({ router: app, adminSecret, webChannel, approvalStore, auditLog })
+        log.info('Web approval UI enabled at /admin/approvals')
+      }
+
+      if (channels.length === 0) {
         throw new Error(
-          'Telegram chat ID is required. Set LUCIFER_TELEGRAM_CHAT_ID env var or telegramChatId in config.',
+          'No approval channels configured. Set LUCIFER_TELEGRAM_TOKEN + LUCIFER_TELEGRAM_CHAT_ID for Telegram, ' +
+          'or LUCIFER_ADMIN_SECRET for web UI, or use --auto-approve for development.',
         )
       }
-      approvalChannel = createTelegramApprovalChannel(token, chatId, pendingStore, approvalStore, auditLog)
+
+      approvalChannel = channels.length === 1 ? channels[0] : createMultiApprovalChannel(channels)
     }
 
     registerExecuteRoutes({

--- a/server/src/domains/command-gateway/api/approval_page.html
+++ b/server/src/domains/command-gateway/api/approval_page.html
@@ -101,7 +101,6 @@ function doLogin() {
     if (!r.ok) throw new Error('auth');
     return r.json();
   }).then(() => {
-    sessionStorage.setItem('lucifer_secret', secret);
     showApp();
   }).catch(() => {
     document.getElementById('login-error').style.display = 'block';
@@ -298,13 +297,8 @@ async function decide(requestId, action, matchType, duration) {
   }
 }
 
-// Auto-login if secret is in sessionStorage
+// Initialize
 (function init() {
-  const saved = sessionStorage.getItem('lucifer_secret');
-  if (saved) {
-    secret = saved;
-    showApp();
-  }
   // Enter key on login
   document.getElementById('secret-input').addEventListener('keydown', (e) => {
     if (e.key === 'Enter') doLogin();

--- a/server/src/domains/command-gateway/api/approval_page.html
+++ b/server/src/domains/command-gateway/api/approval_page.html
@@ -24,7 +24,7 @@
   .login-error { color: #f85149; font-size: 13px; margin-bottom: 8px; display: none; }
   .empty-state { text-align: center; padding: 80px 24px; color: #8b949e; font-size: 15px; }
   .loading { text-align: center; padding: 80px 24px; color: #8b949e; }
-  .error-banner { background: #f8514922; border: 1px solid #f85149; border-radius: 6px; padding: 12px 16px; margin-bottom: 16px; color: #ff7b72; font-size: 13px; display: none; }
+  .error-banner { background: #2d1215; border: 1px solid #f85149; border-radius: 6px; padding: 12px 16px; margin-bottom: 16px; color: #ff7b72; font-size: 13px; display: none; }
   .toast { position: fixed; bottom: 24px; right: 24px; background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 12px 20px; font-size: 13px; opacity: 0; transition: opacity 0.3s; pointer-events: none; z-index: 100; }
   .toast.visible { opacity: 1; }
   .toast.success { border-color: #3fb950; color: #3fb950; }
@@ -37,12 +37,12 @@
   .card-body { padding: 16px; }
   .command-line { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 15px; color: #f0f6fc; background: #0d1117; padding: 10px 14px; border-radius: 6px; margin-bottom: 12px; word-break: break-all; display: flex; align-items: flex-start; gap: 10px; }
   .risk-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; }
-  .risk-safe { background: #23894433; color: #56d364; }
-  .risk-warning { background: #d2992233; color: #e3b341; }
-  .risk-danger { background: #f8514933; color: #ff7b72; }
+  .risk-safe { background: #1b3526; color: #7ee787; }
+  .risk-warning { background: #2e2a1b; color: #e3b341; }
+  .risk-danger { background: #2d1215; color: #ff7b72; }
   .meta { font-size: 12px; color: #8b949e; margin-bottom: 12px; display: flex; gap: 16px; flex-wrap: wrap; }
   .meta span { display: inline-flex; align-items: center; gap: 4px; }
-  .warnings { font-size: 12px; color: #e3b341; margin-bottom: 12px; padding: 8px 12px; background: #d2992215; border-radius: 4px; }
+  .warnings { font-size: 12px; color: #e3b341; margin-bottom: 12px; padding: 8px 12px; background: #1f1d15; border-radius: 4px; }
   .warnings li { margin-left: 16px; margin-bottom: 2px; }
   .actions { display: flex; gap: 8px; flex-wrap: wrap; }
   .btn { padding: 6px 14px; border: 1px solid #30363d; border-radius: 6px; background: #21262d; color: #c9d1d9; font-size: 13px; cursor: pointer; transition: all 0.15s; }

--- a/server/src/domains/command-gateway/api/approval_page.html
+++ b/server/src/domains/command-gateway/api/approval_page.html
@@ -24,7 +24,7 @@
   .login-error { color: #f85149; font-size: 13px; margin-bottom: 8px; display: none; }
   .empty-state { text-align: center; padding: 80px 24px; color: #8b949e; font-size: 15px; }
   .loading { text-align: center; padding: 80px 24px; color: #8b949e; }
-  .error-banner { background: #f8514922; border: 1px solid #f85149; border-radius: 6px; padding: 12px 16px; margin-bottom: 16px; color: #f85149; font-size: 13px; display: none; }
+  .error-banner { background: #f8514922; border: 1px solid #f85149; border-radius: 6px; padding: 12px 16px; margin-bottom: 16px; color: #ff7b72; font-size: 13px; display: none; }
   .toast { position: fixed; bottom: 24px; right: 24px; background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 12px 20px; font-size: 13px; opacity: 0; transition: opacity 0.3s; pointer-events: none; z-index: 100; }
   .toast.visible { opacity: 1; }
   .toast.success { border-color: #3fb950; color: #3fb950; }
@@ -37,12 +37,12 @@
   .card-body { padding: 16px; }
   .command-line { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 15px; color: #f0f6fc; background: #0d1117; padding: 10px 14px; border-radius: 6px; margin-bottom: 12px; word-break: break-all; display: flex; align-items: flex-start; gap: 10px; }
   .risk-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; }
-  .risk-safe { background: #23894422; color: #3fb950; }
-  .risk-warning { background: #d2992222; color: #d29922; }
-  .risk-danger { background: #f8514922; color: #f85149; }
+  .risk-safe { background: #23894433; color: #56d364; }
+  .risk-warning { background: #d2992233; color: #e3b341; }
+  .risk-danger { background: #f8514933; color: #ff7b72; }
   .meta { font-size: 12px; color: #8b949e; margin-bottom: 12px; display: flex; gap: 16px; flex-wrap: wrap; }
   .meta span { display: inline-flex; align-items: center; gap: 4px; }
-  .warnings { font-size: 12px; color: #d29922; margin-bottom: 12px; padding: 8px 12px; background: #d2992210; border-radius: 4px; }
+  .warnings { font-size: 12px; color: #e3b341; margin-bottom: 12px; padding: 8px 12px; background: #d2992215; border-radius: 4px; }
   .warnings li { margin-left: 16px; margin-bottom: 2px; }
   .actions { display: flex; gap: 8px; flex-wrap: wrap; }
   .btn { padding: 6px 14px; border: 1px solid #30363d; border-radius: 6px; background: #21262d; color: #c9d1d9; font-size: 13px; cursor: pointer; transition: all 0.15s; }
@@ -185,7 +185,8 @@ function setStatus(state) {
   const dot = document.getElementById('status-dot');
   const text = document.getElementById('status-text');
   dot.className = 'status-dot ' + state;
-  text.textContent = state === 'connected' ? 'Connected' : state === 'connecting' ? 'Connecting...' : 'Disconnected';
+  const labels = { connected: 'Connected', connecting: 'Connecting...', disconnected: 'Disconnected' };
+  text.textContent = labels[state] || 'Unknown';
 }
 
 function showError(msg) { const el = document.getElementById('error-banner'); el.textContent = msg; el.style.display = 'block'; }
@@ -219,8 +220,9 @@ function renderCards() {
     container.insertAdjacentHTML('afterbegin', buildCard(req));
   }
 
-  // Remove cards no longer pending
-  for (const child of [...container.children]) {
+  // Remove cards no longer pending (copy to array since we mutate during iteration)
+  const children = Array.from(container.children);
+  for (const child of children) {
     const cid = child.id.replace('card-', '');
     if (!pending.has(cid) && !child.classList.contains('slide-out')) {
       child.remove();
@@ -267,7 +269,7 @@ function buildCard(req) {
 }
 
 function escHtml(s) {
-  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  return String(s).replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;').replaceAll('"','&quot;');
 }
 
 async function decide(requestId, action, matchType, duration) {

--- a/server/src/domains/command-gateway/api/approval_page.html
+++ b/server/src/domains/command-gateway/api/approval_page.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lucifer Approvals</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace; background: #0d1117; color: #c9d1d9; min-height: 100vh; }
+  .header { background: #161b22; border-bottom: 1px solid #30363d; padding: 16px 24px; display: flex; align-items: center; justify-content: space-between; }
+  .header h1 { font-size: 18px; font-weight: 600; }
+  .status { display: flex; align-items: center; gap: 8px; font-size: 13px; color: #8b949e; }
+  .status-dot { width: 8px; height: 8px; border-radius: 50%; }
+  .status-dot.connected { background: #3fb950; }
+  .status-dot.disconnected { background: #f85149; animation: pulse 2s infinite; }
+  .status-dot.connecting { background: #d29922; animation: pulse 1s infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+  .container { max-width: 900px; margin: 0 auto; padding: 24px; }
+  .login-form { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 32px; max-width: 400px; margin: 80px auto; }
+  .login-form h2 { margin-bottom: 16px; font-size: 16px; }
+  .login-form input { width: 100%; padding: 8px 12px; background: #0d1117; border: 1px solid #30363d; border-radius: 6px; color: #c9d1d9; font-size: 14px; margin-bottom: 12px; }
+  .login-form button { width: 100%; padding: 8px 12px; background: #238636; border: none; border-radius: 6px; color: #fff; font-size: 14px; cursor: pointer; }
+  .login-form button:hover { background: #2ea043; }
+  .login-error { color: #f85149; font-size: 13px; margin-bottom: 8px; display: none; }
+  .empty-state { text-align: center; padding: 80px 24px; color: #8b949e; font-size: 15px; }
+  .loading { text-align: center; padding: 80px 24px; color: #8b949e; }
+  .error-banner { background: #f8514922; border: 1px solid #f85149; border-radius: 6px; padding: 12px 16px; margin-bottom: 16px; color: #f85149; font-size: 13px; display: none; }
+  .toast { position: fixed; bottom: 24px; right: 24px; background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 12px 20px; font-size: 13px; opacity: 0; transition: opacity 0.3s; pointer-events: none; z-index: 100; }
+  .toast.visible { opacity: 1; }
+  .toast.success { border-color: #3fb950; color: #3fb950; }
+  .toast.error { border-color: #f85149; color: #f85149; }
+  .card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; margin-bottom: 12px; overflow: hidden; transition: all 0.3s; }
+  .card.deciding { opacity: 0.6; pointer-events: none; }
+  .card.approved { border-color: #3fb950; background: #3fb95010; }
+  .card.denied { border-color: #f85149; background: #f8514910; }
+  .card.slide-out { opacity: 0; transform: translateX(100px); max-height: 0; margin-bottom: 0; padding: 0; }
+  .card-body { padding: 16px; }
+  .command-line { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 15px; color: #f0f6fc; background: #0d1117; padding: 10px 14px; border-radius: 6px; margin-bottom: 12px; word-break: break-all; display: flex; align-items: flex-start; gap: 10px; }
+  .risk-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; white-space: nowrap; flex-shrink: 0; }
+  .risk-safe { background: #23894422; color: #3fb950; }
+  .risk-warning { background: #d2992222; color: #d29922; }
+  .risk-danger { background: #f8514922; color: #f85149; }
+  .meta { font-size: 12px; color: #8b949e; margin-bottom: 12px; display: flex; gap: 16px; flex-wrap: wrap; }
+  .meta span { display: inline-flex; align-items: center; gap: 4px; }
+  .warnings { font-size: 12px; color: #d29922; margin-bottom: 12px; padding: 8px 12px; background: #d2992210; border-radius: 4px; }
+  .warnings li { margin-left: 16px; margin-bottom: 2px; }
+  .actions { display: flex; gap: 8px; flex-wrap: wrap; }
+  .btn { padding: 6px 14px; border: 1px solid #30363d; border-radius: 6px; background: #21262d; color: #c9d1d9; font-size: 13px; cursor: pointer; transition: all 0.15s; }
+  .btn:hover { background: #30363d; }
+  .btn-approve { border-color: #238636; color: #3fb950; }
+  .btn-approve:hover { background: #238636; color: #fff; }
+  .btn-deny { border-color: #da3633; color: #f85149; }
+  .btn-deny:hover { background: #da3633; color: #fff; }
+  .btn-group-label { font-size: 11px; color: #8b949e; margin-right: 4px; align-self: center; }
+</style>
+</head>
+<body>
+
+<div id="login-view">
+  <div class="login-form">
+    <h2>Lucifer Admin</h2>
+    <div class="login-error" id="login-error">Invalid secret</div>
+    <input type="password" id="secret-input" placeholder="Admin secret" autocomplete="off">
+    <button onclick="doLogin()">Connect</button>
+  </div>
+</div>
+
+<div id="app-view" style="display:none">
+  <div class="header">
+    <h1>Lucifer Approvals</h1>
+    <div class="status">
+      <div class="status-dot connecting" id="status-dot"></div>
+      <span id="status-text">Connecting...</span>
+    </div>
+  </div>
+  <div class="container">
+    <div class="error-banner" id="error-banner"></div>
+    <div id="loading" class="loading">Loading...</div>
+    <div id="empty" class="empty-state" style="display:none">No pending approval requests</div>
+    <div id="cards"></div>
+  </div>
+</div>
+
+<div class="toast" id="toast"></div>
+
+<script>
+let secret = '';
+let evtSource = null;
+let reconnectTimer = null;
+const pending = new Map();
+
+function doLogin() {
+  secret = document.getElementById('secret-input').value.trim();
+  if (!secret) return;
+  document.getElementById('login-error').style.display = 'none';
+
+  // Test auth with a pending list request
+  fetch('/api/v1/admin/approvals/pending', {
+    headers: { 'Authorization': 'Bearer ' + secret }
+  }).then(r => {
+    if (!r.ok) throw new Error('auth');
+    return r.json();
+  }).then(() => {
+    sessionStorage.setItem('lucifer_secret', secret);
+    showApp();
+  }).catch(() => {
+    document.getElementById('login-error').style.display = 'block';
+  });
+}
+
+function showApp() {
+  document.getElementById('login-view').style.display = 'none';
+  document.getElementById('app-view').style.display = 'block';
+  connectSSE();
+}
+
+async function connectSSE() {
+  setStatus('connecting');
+  try {
+    const ticketRes = await fetch('/api/v1/admin/approvals/stream-ticket', {
+      method: 'POST',
+      headers: { 'Authorization': 'Bearer ' + secret, 'Content-Type': 'application/json' }
+    });
+    if (!ticketRes.ok) throw new Error('ticket');
+    const { ticket } = await ticketRes.json();
+
+    if (evtSource) evtSource.close();
+    evtSource = new EventSource('/api/v1/admin/approvals/stream?ticket=' + ticket);
+
+    evtSource.addEventListener('init', (e) => {
+      const data = JSON.parse(e.data);
+      pending.clear();
+      data.pending.forEach(r => pending.set(r.requestId, r));
+      renderCards();
+      setStatus('connected');
+      document.getElementById('loading').style.display = 'none';
+    });
+
+    evtSource.addEventListener('new_request', (e) => {
+      const req = JSON.parse(e.data);
+      pending.set(req.requestId, req);
+      renderCards();
+    });
+
+    evtSource.addEventListener('request_decided', (e) => {
+      const data = JSON.parse(e.data);
+      const card = document.getElementById('card-' + data.requestId);
+      if (card) {
+        card.classList.add(data.decision === 'approved' ? 'approved' : 'denied');
+        setTimeout(() => {
+          card.classList.add('slide-out');
+          setTimeout(() => {
+            pending.delete(data.requestId);
+            renderCards();
+          }, 300);
+        }, 800);
+      } else {
+        pending.delete(data.requestId);
+        renderCards();
+      }
+    });
+
+    evtSource.onerror = () => {
+      setStatus('disconnected');
+      evtSource.close();
+      evtSource = null;
+      scheduleReconnect();
+    };
+  } catch {
+    setStatus('disconnected');
+    scheduleReconnect();
+  }
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer) return;
+  showError('Connection lost. Reconnecting...');
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    hideError();
+    connectSSE();
+  }, 3000);
+}
+
+function setStatus(state) {
+  const dot = document.getElementById('status-dot');
+  const text = document.getElementById('status-text');
+  dot.className = 'status-dot ' + state;
+  text.textContent = state === 'connected' ? 'Connected' : state === 'connecting' ? 'Connecting...' : 'Disconnected';
+}
+
+function showError(msg) { const el = document.getElementById('error-banner'); el.textContent = msg; el.style.display = 'block'; }
+function hideError() { document.getElementById('error-banner').style.display = 'none'; }
+
+function showToast(msg, type) {
+  const el = document.getElementById('toast');
+  el.textContent = msg;
+  el.className = 'toast visible ' + type;
+  setTimeout(() => el.classList.remove('visible'), 3000);
+}
+
+function renderCards() {
+  const container = document.getElementById('cards');
+  const empty = document.getElementById('empty');
+  if (pending.size === 0) {
+    container.innerHTML = '';
+    empty.style.display = 'block';
+    return;
+  }
+  empty.style.display = 'none';
+
+  // Preserve existing cards, add new ones
+  const existingIds = new Set();
+  for (const child of container.children) {
+    existingIds.add(child.id.replace('card-', ''));
+  }
+
+  for (const [id, req] of pending) {
+    if (existingIds.has(id)) continue;
+    container.insertAdjacentHTML('afterbegin', buildCard(req));
+  }
+
+  // Remove cards no longer pending
+  for (const child of [...container.children]) {
+    const cid = child.id.replace('card-', '');
+    if (!pending.has(cid) && !child.classList.contains('slide-out')) {
+      child.remove();
+    }
+  }
+}
+
+function buildCard(req) {
+  const risk = req.riskAnalysis || { level: 'safe', warnings: [] };
+  const riskClass = 'risk-' + risk.level;
+  const riskLabel = risk.level.toUpperCase();
+  const prefix = req.command.split(/\s+/).slice(0, 2).join(' ');
+  const warnings = risk.warnings && risk.warnings.length > 0
+    ? '<ul class="warnings">' + risk.warnings.map(w => '<li>' + escHtml(w) + '</li>').join('') + '</ul>'
+    : '';
+  const ts = new Date(req.createdAt).toLocaleTimeString();
+
+  return '<div class="card" id="card-' + req.requestId + '">' +
+    '<div class="card-body">' +
+      '<div class="command-line">' +
+        '<span class="risk-badge ' + riskClass + '">' + riskLabel + '</span>' +
+        '<code>' + escHtml(req.command) + '</code>' +
+      '</div>' +
+      '<div class="meta">' +
+        '<span>Key: <strong>' + escHtml(req.apiKeyName) + '</strong></span>' +
+        '<span>IP: ' + escHtml(req.ip) + '</span>' +
+        '<span>ID: ' + req.requestId.slice(0, 8) + '</span>' +
+        '<span>' + ts + '</span>' +
+      '</div>' +
+      warnings +
+      '<div class="actions">' +
+        '<span class="btn-group-label">Exact:</span>' +
+        '<button class="btn btn-approve" onclick="decide(\'' + req.requestId + '\',\'approve\',\'exact\',\'2\')">2h</button>' +
+        '<button class="btn btn-approve" onclick="decide(\'' + req.requestId + '\',\'approve\',\'exact\',\'8\')">8h</button>' +
+        '<button class="btn btn-approve" onclick="decide(\'' + req.requestId + '\',\'approve\',\'exact\',\'permanent\')">Permanent</button>' +
+        '<span class="btn-group-label" style="margin-left:8px">Prefix "' + escHtml(prefix) + '":</span>' +
+        '<button class="btn btn-approve" onclick="decide(\'' + req.requestId + '\',\'approve\',\'prefix\',\'2\')">2h</button>' +
+        '<button class="btn btn-approve" onclick="decide(\'' + req.requestId + '\',\'approve\',\'prefix\',\'8\')">8h</button>' +
+        '<span style="flex-grow:1"></span>' +
+        '<button class="btn btn-deny" onclick="decide(\'' + req.requestId + '\',\'deny\',\'exact\',\'0\')">Deny</button>' +
+      '</div>' +
+    '</div>' +
+  '</div>';
+}
+
+function escHtml(s) {
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+async function decide(requestId, action, matchType, duration) {
+  const card = document.getElementById('card-' + requestId);
+  if (card) card.classList.add('deciding');
+
+  try {
+    const res = await fetch('/api/v1/admin/approvals/' + requestId + '/decide', {
+      method: 'POST',
+      headers: { 'Authorization': 'Bearer ' + secret, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, matchType, duration })
+    });
+    if (res.status === 409) {
+      showToast('Request already decided', 'error');
+      pending.delete(requestId);
+      renderCards();
+      return;
+    }
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.message || 'Request failed');
+    }
+    // SSE will handle the UI update via request_decided event
+  } catch (err) {
+    if (card) card.classList.remove('deciding');
+    showToast(err.message || 'Failed to submit decision', 'error');
+  }
+}
+
+// Auto-login if secret is in sessionStorage
+(function init() {
+  const saved = sessionStorage.getItem('lucifer_secret');
+  if (saved) {
+    secret = saved;
+    showApp();
+  }
+  // Enter key on login
+  document.getElementById('secret-input').addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') doLogin();
+  });
+})();
+</script>
+</body>
+</html>

--- a/server/src/domains/command-gateway/api/register_approval_routes.ts
+++ b/server/src/domains/command-gateway/api/register_approval_routes.ts
@@ -85,6 +85,47 @@ function checkAdminAuth(adminSecret: string, req: Request, res: Response): boole
   return true;
 }
 
+interface DecideInput {
+  action: string;
+  matchType?: string;
+  duration?: string;
+}
+
+interface ValidatedDecision {
+  decision: ApprovalDecision;
+  matchType: ApprovalMatchType;
+  duration: string;
+}
+
+function validateDecideInput(body: DecideInput): ValidatedDecision | ErrorResponse {
+  const { action, matchType, duration } = body;
+
+  if (!action || (action !== 'approve' && action !== 'deny')) {
+    return { code: 'INVALID_ACTION', message: 'action must be "approve" or "deny"', retryable: false };
+  }
+
+  const decision: ApprovalDecision = action === 'approve' ? 'approved' : 'denied';
+
+  if (decision === 'approved') {
+    if (!matchType || (matchType !== 'exact' && matchType !== 'prefix')) {
+      return { code: 'INVALID_MATCH_TYPE', message: 'matchType must be "exact" or "prefix" when approving', retryable: false };
+    }
+    if (!duration || !['2', '8', 'permanent'].includes(duration)) {
+      return { code: 'INVALID_DURATION', message: 'duration must be "2", "8", or "permanent" when approving', retryable: false };
+    }
+  }
+
+  return {
+    decision,
+    matchType: (matchType as ApprovalMatchType) ?? 'exact',
+    duration: duration ?? '0',
+  };
+}
+
+function isValidationError(result: ValidatedDecision | ErrorResponse): result is ErrorResponse {
+  return 'code' in result;
+}
+
 export interface ApprovalRouteDeps {
   router: Router;
   adminSecret: string;
@@ -182,45 +223,13 @@ export function registerApprovalRoutes(deps: ApprovalRouteDeps): void {
     if (!checkAdminAuth(adminSecret, req, res)) return;
 
     const requestId = Array.isArray(req.params.requestId) ? req.params.requestId[0] : req.params.requestId;
-    const { action, matchType, duration } = req.body as {
-      action?: string;
-      matchType?: string;
-      duration?: string;
-    };
-
-    // Validate input
-    if (!action || (action !== 'approve' && action !== 'deny')) {
-      res.status(400).json({
-        code: 'INVALID_ACTION',
-        message: 'action must be "approve" or "deny"',
-        retryable: false,
-      } satisfies ErrorResponse);
+    const validated = validateDecideInput(req.body as DecideInput);
+    if (isValidationError(validated)) {
+      res.status(400).json(validated);
       return;
     }
 
-    const decision: ApprovalDecision = action === 'approve' ? 'approved' : 'denied';
-
-    if (decision === 'approved') {
-      if (!matchType || (matchType !== 'exact' && matchType !== 'prefix')) {
-        res.status(400).json({
-          code: 'INVALID_MATCH_TYPE',
-          message: 'matchType must be "exact" or "prefix" when approving',
-          retryable: false,
-        } satisfies ErrorResponse);
-        return;
-      }
-      if (!duration || !['2', '8', 'permanent'].includes(duration)) {
-        res.status(400).json({
-          code: 'INVALID_DURATION',
-          message: 'duration must be "2", "8", or "permanent" when approving',
-          retryable: false,
-        } satisfies ErrorResponse);
-        return;
-      }
-    }
-
-    const resolvedMatchType: ApprovalMatchType = (matchType as ApprovalMatchType) ?? 'exact';
-    const resolvedDuration = duration ?? '0';
+    const { decision, matchType: resolvedMatchType, duration: resolvedDuration } = validated;
 
     // Try to resolve via web channel
     const pending = webChannel.getPendingRequests().find(p => p.requestId === requestId);

--- a/server/src/domains/command-gateway/api/register_approval_routes.ts
+++ b/server/src/domains/command-gateway/api/register_approval_routes.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import type { Router, Request, Response } from 'express';
+import rateLimit from 'express-rate-limit';
 import type { ApprovalMatchType, ApprovalDecision, ErrorResponse } from '../types/command_types.js';
 import type { ApprovalStore, AuditLog } from '../types/store_interfaces.js';
 import type { WebApprovalChannelHandle } from '../service/web_approval_channel.js';
@@ -11,31 +12,6 @@ import { createChildLogger } from '../../../lib/logger.js';
 const log = createChildLogger('admin-routes');
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-// Per-IP request rate limiter (sliding window)
-const RATE_WINDOW_MS = 60_000;
-const RATE_MAX_REQUESTS = 60;
-const requestCounts = new Map<string, { count: number; resetAt: number }>();
-
-function rateLimit(req: Request, res: Response): boolean {
-  const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ?? req.socket.remoteAddress ?? 'unknown';
-  const now = Date.now();
-  const entry = requestCounts.get(ip);
-  if (!entry || now > entry.resetAt) {
-    requestCounts.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });
-    return true;
-  }
-  entry.count++;
-  if (entry.count > RATE_MAX_REQUESTS) {
-    res.status(429).json({
-      code: 'RATE_LIMITED',
-      message: 'Too many requests. Try again later.',
-      retryable: true,
-    } satisfies ErrorResponse);
-    return false;
-  }
-  return true;
-}
 
 // Rate limiter for admin auth failures
 interface AuthRateLimit {
@@ -120,6 +96,15 @@ export interface ApprovalRouteDeps {
 export function registerApprovalRoutes(deps: ApprovalRouteDeps): void {
   const { router, adminSecret, webChannel, approvalStore, auditLog } = deps;
 
+  // Rate limiter middleware for admin API routes
+  const adminRateLimiter = rateLimit({
+    windowMs: 60_000,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { code: 'RATE_LIMITED', message: 'Too many requests. Try again later.', retryable: true },
+  });
+
   // Load HTML page at startup -- try compiled location first, then source
   const possiblePaths = [
     path.join(__dirname, 'approval_page.html'),
@@ -137,15 +122,13 @@ export function registerApprovalRoutes(deps: ApprovalRouteDeps): void {
   });
 
   // List pending requests
-  router.get('/api/v1/admin/approvals/pending', (req: Request, res: Response) => {
-    if (!rateLimit(req, res)) return;
+  router.get('/api/v1/admin/approvals/pending', adminRateLimiter, (req: Request, res: Response) => {
     if (!checkAdminAuth(adminSecret, req, res)) return;
     res.json({ pending: webChannel.getPendingRequests() });
   });
 
   // Exchange bearer token for one-time SSE ticket
-  router.post('/api/v1/admin/approvals/stream-ticket', (req: Request, res: Response) => {
-    if (!rateLimit(req, res)) return;
+  router.post('/api/v1/admin/approvals/stream-ticket', adminRateLimiter, (req: Request, res: Response) => {
     if (!checkAdminAuth(adminSecret, req, res)) return;
     const token = randomUUID();
     sseTickets.set(token, { token, createdAt: Date.now() });
@@ -195,8 +178,7 @@ export function registerApprovalRoutes(deps: ApprovalRouteDeps): void {
   });
 
   // Approve or deny a request
-  router.post('/api/v1/admin/approvals/:requestId/decide', (req: Request, res: Response) => {
-    if (!rateLimit(req, res)) return;
+  router.post('/api/v1/admin/approvals/:requestId/decide', adminRateLimiter, (req: Request, res: Response) => {
     if (!checkAdminAuth(adminSecret, req, res)) return;
 
     const requestId = Array.isArray(req.params.requestId) ? req.params.requestId[0] : req.params.requestId;

--- a/server/src/domains/command-gateway/api/register_approval_routes.ts
+++ b/server/src/domains/command-gateway/api/register_approval_routes.ts
@@ -12,6 +12,31 @@ const log = createChildLogger('admin-routes');
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Per-IP request rate limiter (sliding window)
+const RATE_WINDOW_MS = 60_000;
+const RATE_MAX_REQUESTS = 60;
+const requestCounts = new Map<string, { count: number; resetAt: number }>();
+
+function rateLimit(req: Request, res: Response): boolean {
+  const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ?? req.socket.remoteAddress ?? 'unknown';
+  const now = Date.now();
+  const entry = requestCounts.get(ip);
+  if (!entry || now > entry.resetAt) {
+    requestCounts.set(ip, { count: 1, resetAt: now + RATE_WINDOW_MS });
+    return true;
+  }
+  entry.count++;
+  if (entry.count > RATE_MAX_REQUESTS) {
+    res.status(429).json({
+      code: 'RATE_LIMITED',
+      message: 'Too many requests. Try again later.',
+      retryable: true,
+    } satisfies ErrorResponse);
+    return false;
+  }
+  return true;
+}
+
 // Rate limiter for admin auth failures
 interface AuthRateLimit {
   failures: number;
@@ -113,12 +138,14 @@ export function registerApprovalRoutes(deps: ApprovalRouteDeps): void {
 
   // List pending requests
   router.get('/api/v1/admin/approvals/pending', (req: Request, res: Response) => {
+    if (!rateLimit(req, res)) return;
     if (!checkAdminAuth(adminSecret, req, res)) return;
     res.json({ pending: webChannel.getPendingRequests() });
   });
 
   // Exchange bearer token for one-time SSE ticket
   router.post('/api/v1/admin/approvals/stream-ticket', (req: Request, res: Response) => {
+    if (!rateLimit(req, res)) return;
     if (!checkAdminAuth(adminSecret, req, res)) return;
     const token = randomUUID();
     sseTickets.set(token, { token, createdAt: Date.now() });
@@ -169,6 +196,7 @@ export function registerApprovalRoutes(deps: ApprovalRouteDeps): void {
 
   // Approve or deny a request
   router.post('/api/v1/admin/approvals/:requestId/decide', (req: Request, res: Response) => {
+    if (!rateLimit(req, res)) return;
     if (!checkAdminAuth(adminSecret, req, res)) return;
 
     const requestId = Array.isArray(req.params.requestId) ? req.params.requestId[0] : req.params.requestId;

--- a/server/src/domains/command-gateway/api/register_approval_routes.ts
+++ b/server/src/domains/command-gateway/api/register_approval_routes.ts
@@ -1,0 +1,261 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+import type { Router, Request, Response } from 'express';
+import type { ApprovalMatchType, ApprovalDecision, ErrorResponse } from '../types/command_types.js';
+import type { ApprovalStore, AuditLog } from '../types/store_interfaces.js';
+import type { WebApprovalChannelHandle } from '../service/web_approval_channel.js';
+import { createChildLogger } from '../../../lib/logger.js';
+
+const log = createChildLogger('admin-routes');
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Rate limiter for admin auth failures
+interface AuthRateLimit {
+  failures: number;
+  lockedUntil: number;
+}
+
+const authRateLimits = new Map<string, AuthRateLimit>();
+const MAX_FAILURES = 5;
+const LOCKOUT_MS = 60_000;
+
+// Short-lived SSE tickets
+interface SSETicket {
+  token: string;
+  createdAt: number;
+}
+
+const sseTickets = new Map<string, SSETicket>();
+const TICKET_TTL_MS = 10_000;
+
+// Clean up expired tickets periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [token, ticket] of sseTickets.entries()) {
+    if (now - ticket.createdAt > TICKET_TTL_MS) {
+      sseTickets.delete(token);
+    }
+  }
+}, 5_000);
+
+function checkAdminAuth(adminSecret: string, req: Request, res: Response): boolean {
+  const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ?? req.socket.remoteAddress ?? 'unknown';
+
+  // Check lockout
+  const limit = authRateLimits.get(ip);
+  if (limit && Date.now() < limit.lockedUntil) {
+    const retryAfter = Math.ceil((limit.lockedUntil - Date.now()) / 1000);
+    res.status(429).json({
+      code: 'RATE_LIMITED',
+      message: 'Too many failed auth attempts. Try again later.',
+      retryable: true,
+      details: `Locked out for ${retryAfter}s`,
+    } satisfies ErrorResponse & { details: string });
+    return false;
+  }
+
+  const authHeader = req.headers.authorization;
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+
+  if (!token || token !== adminSecret) {
+    // Track failure
+    const current = authRateLimits.get(ip) ?? { failures: 0, lockedUntil: 0 };
+    current.failures++;
+    if (current.failures >= MAX_FAILURES) {
+      current.lockedUntil = Date.now() + LOCKOUT_MS;
+      current.failures = 0;
+      log.warn({ ip }, 'Admin auth locked out after repeated failures');
+    }
+    authRateLimits.set(ip, current);
+
+    res.status(401).json({
+      code: 'UNAUTHORIZED',
+      message: 'Invalid or missing admin secret',
+      retryable: false,
+    } satisfies ErrorResponse);
+    return false;
+  }
+
+  // Reset failures on success
+  authRateLimits.delete(ip);
+  return true;
+}
+
+export interface ApprovalRouteDeps {
+  router: Router;
+  adminSecret: string;
+  webChannel: WebApprovalChannelHandle;
+  approvalStore: ApprovalStore;
+  auditLog: AuditLog;
+}
+
+export function registerApprovalRoutes(deps: ApprovalRouteDeps): void {
+  const { router, adminSecret, webChannel, approvalStore, auditLog } = deps;
+
+  // Load HTML page at startup -- try compiled location first, then source
+  const possiblePaths = [
+    path.join(__dirname, 'approval_page.html'),
+    path.resolve(__dirname, '../../../../server/src/domains/command-gateway/api/approval_page.html'),
+    path.resolve(process.cwd(), 'server/src/domains/command-gateway/api/approval_page.html'),
+  ];
+  const htmlPath = possiblePaths.find(p => fs.existsSync(p));
+  const approvalPageHtml = htmlPath
+    ? fs.readFileSync(htmlPath, 'utf8')
+    : '<html><body><h1>Approval page not found</h1></body></html>';
+
+  // Serve the admin HTML page (no auth - page handles login client-side)
+  router.get('/admin/approvals', (_req: Request, res: Response) => {
+    res.type('html').send(approvalPageHtml);
+  });
+
+  // List pending requests
+  router.get('/api/v1/admin/approvals/pending', (req: Request, res: Response) => {
+    if (!checkAdminAuth(adminSecret, req, res)) return;
+    res.json({ pending: webChannel.getPendingRequests() });
+  });
+
+  // Exchange bearer token for one-time SSE ticket
+  router.post('/api/v1/admin/approvals/stream-ticket', (req: Request, res: Response) => {
+    if (!checkAdminAuth(adminSecret, req, res)) return;
+    const token = randomUUID();
+    sseTickets.set(token, { token, createdAt: Date.now() });
+    res.json({ ticket: token, ttlSeconds: TICKET_TTL_MS / 1000 });
+  });
+
+  // SSE stream for real-time updates
+  router.get('/api/v1/admin/approvals/stream', (req: Request, res: Response) => {
+    const ticket = req.query.ticket as string | undefined;
+    if (!ticket) {
+      res.status(401).json({ code: 'UNAUTHORIZED', message: 'Missing SSE ticket', retryable: false } satisfies ErrorResponse);
+      return;
+    }
+
+    const storedTicket = sseTickets.get(ticket);
+    if (!storedTicket || Date.now() - storedTicket.createdAt > TICKET_TTL_MS) {
+      sseTickets.delete(ticket);
+      res.status(401).json({ code: 'TICKET_EXPIRED', message: 'SSE ticket expired or invalid', retryable: true } satisfies ErrorResponse);
+      return;
+    }
+
+    // Consume ticket (one-time use)
+    sseTickets.delete(ticket);
+
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    });
+
+    // Send initial pending list
+    const pending = webChannel.getPendingRequests();
+    res.write(`event: init\ndata: ${JSON.stringify({ pending })}\n\n`);
+
+    webChannel.addSSEClient(res);
+
+    // Heartbeat to detect broken connections
+    const heartbeat = setInterval(() => {
+      res.write(': heartbeat\n\n');
+    }, 30_000);
+
+    req.on('close', () => {
+      clearInterval(heartbeat);
+      webChannel.removeSSEClient(res);
+    });
+  });
+
+  // Approve or deny a request
+  router.post('/api/v1/admin/approvals/:requestId/decide', (req: Request, res: Response) => {
+    if (!checkAdminAuth(adminSecret, req, res)) return;
+
+    const requestId = Array.isArray(req.params.requestId) ? req.params.requestId[0] : req.params.requestId;
+    const { action, matchType, duration } = req.body as {
+      action?: string;
+      matchType?: string;
+      duration?: string;
+    };
+
+    // Validate input
+    if (!action || (action !== 'approve' && action !== 'deny')) {
+      res.status(400).json({
+        code: 'INVALID_ACTION',
+        message: 'action must be "approve" or "deny"',
+        retryable: false,
+      } satisfies ErrorResponse);
+      return;
+    }
+
+    const decision: ApprovalDecision = action === 'approve' ? 'approved' : 'denied';
+
+    if (decision === 'approved') {
+      if (!matchType || (matchType !== 'exact' && matchType !== 'prefix')) {
+        res.status(400).json({
+          code: 'INVALID_MATCH_TYPE',
+          message: 'matchType must be "exact" or "prefix" when approving',
+          retryable: false,
+        } satisfies ErrorResponse);
+        return;
+      }
+      if (!duration || !['2', '8', 'permanent'].includes(duration)) {
+        res.status(400).json({
+          code: 'INVALID_DURATION',
+          message: 'duration must be "2", "8", or "permanent" when approving',
+          retryable: false,
+        } satisfies ErrorResponse);
+        return;
+      }
+    }
+
+    const resolvedMatchType: ApprovalMatchType = (matchType as ApprovalMatchType) ?? 'exact';
+    const resolvedDuration = duration ?? '0';
+
+    // Try to resolve via web channel
+    const pending = webChannel.getPendingRequests().find(p => p.requestId === requestId);
+    if (!pending) {
+      res.status(409).json({
+        code: 'ALREADY_DECIDED',
+        message: 'Request already decided or expired',
+        retryable: false,
+      } satisfies ErrorResponse);
+      return;
+    }
+
+    if (decision === 'approved') {
+      const approvalCommand = resolvedMatchType === 'prefix'
+        ? pending.command.split(/\s+/).slice(0, 2).join(' ')
+        : pending.command;
+
+      approvalStore.addApproval(
+        approvalCommand,
+        resolvedMatchType,
+        resolvedDuration,
+        'web:admin',
+      );
+    }
+
+    auditLog.append({
+      ts: new Date().toISOString(),
+      type: decision === 'approved' ? 'approved' : 'denied',
+      requestId,
+      command: pending.command,
+      duration: decision === 'approved' ? resolvedDuration : undefined,
+      approvedBy: 'web:admin',
+    });
+
+    const resolved = webChannel.resolveRequest(requestId, decision, resolvedMatchType, resolvedDuration);
+    if (!resolved) {
+      res.status(409).json({
+        code: 'ALREADY_DECIDED',
+        message: 'Request was decided by another channel',
+        retryable: false,
+      } satisfies ErrorResponse);
+      return;
+    }
+
+    log.info({ requestId, decision, matchType: resolvedMatchType, duration: resolvedDuration }, 'Admin decision via web UI');
+    res.json({ ok: true, requestId, decision });
+  });
+}

--- a/server/src/domains/command-gateway/service/multi_approval_channel.ts
+++ b/server/src/domains/command-gateway/service/multi_approval_channel.ts
@@ -1,0 +1,44 @@
+import type { ApprovalChannel } from '../types/command_types.js';
+import { createChildLogger } from '../../../lib/logger.js';
+
+const log = createChildLogger('multi-channel');
+
+export function createMultiApprovalChannel(channels: ApprovalChannel[]): ApprovalChannel {
+  if (channels.length === 0) {
+    throw new Error('At least one approval channel is required');
+  }
+
+  return {
+    async requestApproval(command, apiKeyName, ip, requestId, riskAnalysis) {
+      const promises = channels.map(ch =>
+        ch.requestApproval(command, apiKeyName, ip, requestId, riskAnalysis),
+      );
+
+      const result = await Promise.race(promises);
+
+      // Clean up losing channels' internal state
+      for (const ch of channels) {
+        ch.cancel?.(requestId);
+      }
+
+      log.info({ requestId, decision: result.decision }, 'Multi-channel approval resolved');
+      return result;
+    },
+
+    async start() {
+      await Promise.all(channels.map(ch => ch.start()));
+      log.info({ channelCount: channels.length }, 'All approval channels started');
+    },
+
+    async stop() {
+      await Promise.all(channels.map(ch => ch.stop()));
+      log.info('All approval channels stopped');
+    },
+
+    cancel(requestId: string) {
+      for (const ch of channels) {
+        ch.cancel?.(requestId);
+      }
+    },
+  };
+}

--- a/server/src/domains/command-gateway/service/request_telegram_approval.ts
+++ b/server/src/domains/command-gateway/service/request_telegram_approval.ts
@@ -55,6 +55,9 @@ export function createTelegramApprovalChannel(
       );
     }
 
+    // Store decision metadata so the Promise resolve can read the actual values
+    decisionMeta.set(requestId, { matchType: matchType as ApprovalMatchType, duration });
+
     auditLog.append({
       ts: new Date().toISOString(),
       type: decision === 'approved' ? 'approved' : 'denied',
@@ -74,8 +77,36 @@ export function createTelegramApprovalChannel(
     );
   });
 
+  // Track per-request decision metadata from callbacks
+  const decisionMeta = new Map<string, { matchType: ApprovalMatchType; duration: string }>();
+
   return {
     async requestApproval(command, apiKeyName, ip, requestId, riskAnalysis) {
+      // Wire Promise callbacks BEFORE sending the notification to avoid race condition
+      const approvalPromise = new Promise<{ decision: ApprovalDecision; matchType: ApprovalMatchType; duration: string }>((resolve, reject) => {
+        const pending = pendingStore.get(requestId);
+        if (!pending) {
+          reject(new Error('Request not found in pending store'));
+          return;
+        }
+
+        const originalResolve = pending.resolve;
+        const originalReject = pending.reject;
+
+        pending.resolve = (decision: ApprovalDecision) => {
+          const meta = decisionMeta.get(requestId) ?? { matchType: 'exact' as ApprovalMatchType, duration: '2' };
+          decisionMeta.delete(requestId);
+          originalResolve(decision);
+          resolve({ decision, matchType: meta.matchType, duration: meta.duration });
+        };
+
+        pending.reject = (reason: Error) => {
+          decisionMeta.delete(requestId);
+          originalReject(reason);
+          reject(reason);
+        };
+      });
+
       let text = `\u{1f6a8} **Command Request**\n\n`;
       text += `From: \`${apiKeyName}\` (${ip})\n`;
       text += `ID: \`${requestId}\`\n\n`;
@@ -119,28 +150,7 @@ export function createTelegramApprovalChannel(
 
       log.info({ requestId, command, chatId }, 'Telegram approval request sent');
 
-      return new Promise((resolve, reject) => {
-        const pending = pendingStore.get(requestId);
-        if (!pending) {
-          reject(new Error('Request not found in pending store'));
-          return;
-        }
-
-        const originalResolve = pending.resolve;
-        const originalReject = pending.reject;
-
-        pending.resolve = (decision: ApprovalDecision) => {
-          const matchType: ApprovalMatchType = 'exact';
-          const duration = 'unknown';
-          originalResolve(decision);
-          resolve({ decision, matchType, duration });
-        };
-
-        pending.reject = (reason: Error) => {
-          originalReject(reason);
-          reject(reason);
-        };
-      });
+      return approvalPromise;
     },
 
     async start() {

--- a/server/src/domains/command-gateway/service/web_approval_channel.ts
+++ b/server/src/domains/command-gateway/service/web_approval_channel.ts
@@ -1,0 +1,123 @@
+import type { Response } from 'express';
+import type {
+  ApprovalChannel, ApprovalDecision, ApprovalMatchType, ShellRiskAnalysis,
+} from '../types/command_types.js';
+import { createChildLogger } from '../../../lib/logger.js';
+
+const log = createChildLogger('web-channel');
+
+export interface WebPendingRequest {
+  requestId: string;
+  command: string;
+  apiKeyName: string;
+  ip: string;
+  createdAt: string;
+  riskAnalysis: ShellRiskAnalysis;
+}
+
+interface WebCallback {
+  request: WebPendingRequest;
+  resolve: (result: { decision: ApprovalDecision; matchType: ApprovalMatchType; duration: string }) => void;
+  reject: (reason: Error) => void;
+}
+
+export interface WebApprovalChannelHandle extends ApprovalChannel {
+  getPendingRequests(): WebPendingRequest[];
+  resolveRequest(
+    requestId: string,
+    decision: ApprovalDecision,
+    matchType: ApprovalMatchType,
+    duration: string,
+  ): boolean;
+  addSSEClient(res: Response): void;
+  removeSSEClient(res: Response): void;
+}
+
+export function createWebApprovalChannel(): WebApprovalChannelHandle {
+  const callbacks = new Map<string, WebCallback>();
+  const sseClients = new Set<Response>();
+
+  function broadcast(event: string, data: unknown): void {
+    const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    for (const client of sseClients) {
+      client.write(payload);
+    }
+  }
+
+  return {
+    async requestApproval(command, apiKeyName, ip, requestId, riskAnalysis) {
+      const request: WebPendingRequest = {
+        requestId,
+        command,
+        apiKeyName,
+        ip,
+        createdAt: new Date().toISOString(),
+        riskAnalysis,
+      };
+
+      const promise = new Promise<{ decision: ApprovalDecision; matchType: ApprovalMatchType; duration: string }>(
+        (resolve, reject) => {
+          callbacks.set(requestId, { request, resolve, reject });
+        },
+      );
+
+      broadcast('new_request', request);
+
+      log.info({ requestId, command }, 'Web approval request broadcast');
+      return promise;
+    },
+
+    async start() {
+      log.info('Web approval channel started');
+    },
+
+    async stop() {
+      // Reject all pending callbacks
+      for (const [requestId, cb] of callbacks.entries()) {
+        cb.reject(new Error('Web approval channel shutting down'));
+        callbacks.delete(requestId);
+      }
+      // Close all SSE connections
+      for (const client of sseClients) {
+        client.end();
+      }
+      sseClients.clear();
+      log.info('Web approval channel stopped');
+    },
+
+    cancel(requestId: string) {
+      const cb = callbacks.get(requestId);
+      if (cb) {
+        callbacks.delete(requestId);
+        broadcast('request_decided', { requestId, decision: 'cancelled' });
+        log.debug({ requestId }, 'Web channel request cancelled (decided via another channel)');
+      }
+    },
+
+    getPendingRequests(): WebPendingRequest[] {
+      return Array.from(callbacks.values()).map(cb => cb.request);
+    },
+
+    resolveRequest(requestId, decision, matchType, duration) {
+      const cb = callbacks.get(requestId);
+      if (!cb) {
+        return false;
+      }
+      callbacks.delete(requestId);
+      cb.resolve({ decision, matchType, duration });
+      broadcast('request_decided', { requestId, decision, matchType, duration });
+      log.info({ requestId, decision, matchType, duration }, 'Web approval resolved');
+      return true;
+    },
+
+    addSSEClient(res: Response) {
+      sseClients.add(res);
+      log.debug({ clientCount: sseClients.size }, 'SSE client connected');
+    },
+
+    removeSSEClient(res: Response) {
+      sseClients.delete(res);
+      log.debug({ clientCount: sseClients.size }, 'SSE client disconnected');
+    },
+  };
+}

--- a/server/src/domains/command-gateway/types/command_types.ts
+++ b/server/src/domains/command-gateway/types/command_types.ts
@@ -99,7 +99,7 @@ export interface LuciferConfig {
 
 export interface AuditEntry {
   ts: string;
-  type: 'request' | 'rule_match' | 'approval_check' | 'telegram_sent' | 'approved' | 'denied' | 'executed' | 'error';
+  type: 'request' | 'rule_match' | 'approval_check' | 'telegram_sent' | 'web_sent' | 'approved' | 'denied' | 'executed' | 'error';
   requestId: string;
   command?: string;
   apiKeyName?: string;
@@ -130,4 +130,5 @@ export interface ApprovalChannel {
 
   start(): Promise<void>;
   stop(): Promise<void>;
+  cancel?(requestId: string): void;
 }


### PR DESCRIPTION
## Summary

- Add minimal admin web UI for command approval at `/admin/approvals`
- Multi-channel broadcast: approval requests sent to all configured channels (Telegram + Web) in parallel, first response wins
- SSE-powered real-time updates with ticket-based auth (no admin secret in query params)
- Fix two existing Telegram bugs: race condition in callback wiring and hardcoded matchType/duration

## Changes

### New files
- `web_approval_channel.ts` -- ApprovalChannel implementation with SSE broadcast
- `multi_approval_channel.ts` -- Promise.race wrapper with cancel() cleanup
- `register_approval_routes.ts` -- Admin API routes with rate-limited auth
- `approval_page.html` -- Dark-themed standalone admin page

### Modified files
- `command_types.ts` -- added `web_sent` audit type, optional `cancel()` on ApprovalChannel
- `request_telegram_approval.ts` -- fixed race condition + matchType/duration passthrough
- `create_app.ts` -- multi-channel wiring, web channel auto-enabled via LUCIFER_ADMIN_SECRET

## How to use

Set `LUCIFER_ADMIN_SECRET=your-secret` env var and navigate to `/admin/approvals`.
Works alongside Telegram or standalone.

## Test plan

- [x] `npm run lint` -- clean
- [x] `npm test` -- 141/141 pass
- [x] `npm run build` -- clean
- [ ] Manual: SSE stream delivers new requests
- [ ] Manual: approve/deny via web UI
- [ ] Manual: multi-channel race (Telegram + Web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)