### PR TITLE
fix: correct Azure deploy workflow push trigger branch

### DIFF
--- a/.github/workflows/azure-container-apps.yml
+++ b/.github/workflows/azure-container-apps.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Changed the push trigger branch in `.github/workflows/azure-container-apps.yml` from `main` to `master`
- The repository's default branch is `master`, so the Azure Container Apps deployment workflow was never firing on push events

## Test plan
- [ ] Verify the workflow file change is correct (one-line diff)
- [ ] Confirm CI checks pass
- [ ] Validate that the workflow would trigger on pushes to `master` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)