### PR TITLE
refactor(command-gateway)!: sync-only execute + clean CLI exit

### DIFF
--- a/.claude/agents/pr-cycle.md
+++ b/.claude/agents/pr-cycle.md
@@ -18,9 +18,9 @@ You are a senior release engineer responsible for driving a feature branch throu
 
 ## RULES
 
-- NEVER COMMIT ON MASTER WIHTOUT A SMEVER TAG.
-- SEMVER tag are with x.y.z format
-- If the semver Tag can be determined by branch name, you can use it. Otherwise, ask the user to input the tag before merging. Suggest a tag based on the pr.
+- Never commit on master without a semver tag.
+- Semver tags use the `x.y.z` format (no `v` prefix).
+- If the semver tag can be determined from the branch name, you can use it. Otherwise, ask the user to provide the tag before merging. Suggest a tag based on the PR.
 
 ## Workflow
 
@@ -79,6 +79,31 @@ SONARCLOUD_PROJECT_KEY=alkampfergit_lucifer \
 ```
 
 If Sonar reports new issues, treat them as another fix round (Step 3). Do not merge with open Sonar issues.
+
+### Step 4b: Wait for reviewer comments (human and Copilot)
+
+`gh pr view` under-reports Copilot as a requested reviewer. Check the raw
+API too:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/requested_reviewers \
+  --jq '.users[].login, .teams[].slug'
+```
+
+If any reviewer is listed (e.g., `Copilot`), load the
+`github-pr-fixer` skill and follow
+`references/reviewer-comments.md`:
+
+1. Poll until the reviewer leaves `requested_reviewers` AND a review
+   appears under `/pulls/<N>/reviews` (or until a reasonable timeout).
+2. Collect comments from all three surfaces — review bodies, line-level
+   review comments, and PR-issue comments.
+3. Triage and address each actionable comment in a dedicated round.
+4. Post the mandatory audit-trail comment per reviewer-round.
+
+Reviewer-comment rounds share the structure of Step 3 but have their own
+3-round budget. Do not proceed to merge while a reviewer has unresolved
+comments unless the user explicitly authorises it.
 
 ### Step 5: Merge and release
 
@@ -154,5 +179,5 @@ When stopping (success or failure), report:
 
 | Skill | When | Reference docs |
 |-------|------|----------------|
-| `github-pr-fixer` | Open PR, diagnose checks, fix loop, merge | `references/open-pr.md`, `references/pr-resolution.md`, `references/check-diagnosis.md`, `references/fix-loop.md`, `references/release-closure.md` |
+| `github-pr-fixer` | Open PR, diagnose checks, fix loop, handle reviewer comments, merge | `references/open-pr.md`, `references/pr-resolution.md`, `references/check-diagnosis.md`, `references/fix-loop.md`, `references/reviewer-comments.md`, `references/release-closure.md` |
 | `sonar` | Verify/fix SonarCloud issues | `SKILL.md`, `references/fix-workflow.md` |

--- a/.claude/agents/pr-cycle.md
+++ b/.claude/agents/pr-cycle.md
@@ -16,6 +16,12 @@ You are a senior release engineer responsible for driving a feature branch throu
 4. **Document every fix round** as a PR comment so reviewers see exactly what the automation changed.
 5. **Merge and release** via fast-forward to master, tag, push, clean up branches.
 
+## RULES
+
+- NEVER COMMIT ON MASTER WIHTOUT A SMEVER TAG.
+- SEMVER tag are with x.y.z format
+- If the semver Tag can be determined by branch name, you can use it. Otherwise, ask the user to input the tag before merging. Suggest a tag based on the pr.
+
 ## Workflow
 
 ### Step 1: Resolve state

--- a/.claude/skills/github-pr-fixer/SKILL.md
+++ b/.claude/skills/github-pr-fixer/SKILL.md
@@ -5,11 +5,12 @@ description: >
   exhausted. Use when an open PR has failing or pending checks and you need to
   inspect GitHub checks with gh, remediate SonarCloud issues with the sonar
   skill, inspect failed workflow jobs or code scanning alerts, push fixes, and
-  repeat, or when the user wants to open a PR from the current branch or close
-  a ready release PR.
+  repeat. Also covers: opening a PR from the current branch, waiting for a
+  reviewer (human or Copilot) and addressing their line-level comments, and
+  closing a ready release PR.
 metadata:
   author: codex
-  version: 1.2.0
+  version: 1.3.0
   category: workflow
 ---
 
@@ -33,14 +34,17 @@ release flow, or to open a PR from the current branch.
 |------------|------|
 | Open a PR from the current branch | `references/open-pr.md` |
 | Fix failing or pending checks | `references/pr-resolution.md`, then `references/check-diagnosis.md`, then `references/fix-loop.md` |
+| Wait for a reviewer (human or Copilot) and address their comments | `references/reviewer-comments.md` |
 | Close a ready PR and cut a release tag | `references/pr-resolution.md`, then `references/release-closure.md` |
 | Investigate a known standalone CodeQL-style failure pattern | `references/standalone-security-checks.md` |
 
 ## Round limit
 
-- Maximum `3` fix rounds.
+- Maximum `3` check-fix rounds.
 - A round means: inspect failures, make fixes, validate locally, commit, push,
   and wait for checks again.
+- Reviewer-comment rounds have a separate `3`-round budget; see
+  `references/reviewer-comments.md`.
 
 ## Core workflow
 

--- a/.claude/skills/github-pr-fixer/references/reviewer-comments.md
+++ b/.claude/skills/github-pr-fixer/references/reviewer-comments.md
@@ -1,0 +1,145 @@
+# Reference: Addressing reviewer comments
+
+Use this workflow when the PR is already green on CI and the remaining work
+is responding to feedback from a **reviewer** — either a human reviewer or
+an automated reviewer like Copilot Pull Request Reviewer.
+
+This is a distinct phase from the `fix-loop` (which addresses failing
+checks). Reviewer comments may point out:
+
+- Real defects that the automated gates did not catch.
+- Missing edge-case handling, cleanup paths, docstring drift.
+- Typos, grammar, clarity.
+- Design concerns ("consider racing X against Y", "release Z earlier").
+
+Handle this phase after `fix-loop` has run and before any release-closure
+step. Never merge a PR while unresolved reviewer comments exist unless the
+user explicitly tells you to.
+
+## Step 1: Detect requested reviewers
+
+A `gh pr view` call alone may under-report pending reviewer requests,
+especially for GitHub Apps such as Copilot. Use the API endpoint directly:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/requested_reviewers \
+  --jq '.users[].login, .teams[].slug' 2>/dev/null
+```
+
+If the output contains `Copilot` (or any other reviewer), a review has been
+requested but not yet submitted.
+
+## Step 2: Wait for the review to land
+
+Poll until the reviewer disappears from `requested_reviewers` **AND** their
+review shows up under `/pulls/<N>/reviews`, or until a reasonable deadline
+(Copilot typically takes 2–5 minutes for a medium-sized PR; 10 minutes is a
+safe upper bound).
+
+```bash
+for i in $(seq 1 20); do
+  pending=$(gh api repos/<owner>/<repo>/pulls/<N>/requested_reviewers \
+    --jq '[.users[]?.login] | join(",")' 2>/dev/null)
+  reviews=$(gh api repos/<owner>/<repo>/pulls/<N>/reviews \
+    --jq '[.[] | select(.user.login=="Copilot")] | length' 2>/dev/null)
+  echo "poll $i pending=[$pending] copilot_reviews=$reviews"
+  if [ -z "$pending" ] || [ "$reviews" != "0" ]; then break; fi
+  sleep 30
+done
+```
+
+Note: Copilot may post a `COMMENTED` review (no explicit approve/request
+changes). An empty `reviews` count combined with the reviewer having left
+`requested_reviewers` usually means the review DID land — re-check using
+the review listing, not only the filtered count.
+
+## Step 3: Collect every comment surface
+
+A GitHub review has three surfaces; you must inspect all three:
+
+```bash
+# Review-level bodies (summary, state, submitted_at)
+gh api repos/<owner>/<repo>/pulls/<N>/reviews \
+  --jq '.[] | {id,user:.user.login,state,submitted_at,body}'
+
+# Line-level review comments (the most actionable surface)
+gh api repos/<owner>/<repo>/pulls/<N>/comments \
+  --jq '.[] | {id,user:.user.login,path,line,body}'
+
+# Top-level issue comments on the PR (sometimes reviewers use these)
+gh api repos/<owner>/<repo>/issues/<N>/comments \
+  --jq '.[] | {id,user:.user.login,created_at,body: (.body[:200])}'
+```
+
+Present the comments to the user categorised by file and by nature (real
+defect / style / doc / typo). Call out comments that are **outside the PR's
+scope** (for example, pre-existing modifications on the branch that this
+PR did not introduce) — the user may want to skip those.
+
+## Step 4: Fix in a dedicated round
+
+Each round of reviewer-comment fixes follows the same shape as `fix-loop`:
+
+1. **Triage**: classify each comment. Plan the smallest diff that addresses
+   each actionable item.
+2. **Apply**: make the changes. Keep the edits scoped to what the reviewer
+   raised; resist expanding scope.
+3. **Validate locally**:
+   ```bash
+   npm run lint
+   npm test
+   npm run build
+   ```
+4. **Commit and push** one commit per round. Conventional prefix:
+   `fix(review): address Copilot review comments (round N)` or similar.
+5. **Post a PR comment** mirroring the `fix-loop` audit trail, but labeled
+   as reviewer-comment work — list each addressed comment with a 1-line
+   summary and the fix location. Example:
+
+   ```
+   ## Reviewer-comment round 1
+
+   Addressing feedback from @Copilot on review <review-id>:
+
+   - `register_execute_routes.ts:181` — free the pending-store slot as soon
+     as the approval decision lands, so DUPLICATE_IN_FLIGHT only gates
+     awaiting-approval duplicates. Added `PendingRequestStore.release`.
+   - `AGENTS.md:33` — fixed typo / grammar in the semver rule.
+
+   **Commit:** `<sha>` — <commit message>
+   **Local validation:** lint ✓ | test ✓ | build ✓
+   ```
+
+6. **Re-watch checks**. Pushing a new commit re-triggers CI and may cause a
+   re-review.
+
+## Stop conditions
+
+Stop reviewer-comment work when one of:
+
+- Every comment is either addressed with a code/doc change, or explicitly
+  marked as "out of scope / won't fix" with reasoning captured in the PR
+  comment.
+- The user says stop.
+- Three reviewer-comment rounds have been attempted (mirrors the `fix-loop`
+  budget).
+
+When stopping, report:
+
+- Which comments were addressed (and how)
+- Which were deferred (and why)
+- Any comment that could not be addressed within the round budget
+- The PR URL so the user can verify before merging
+
+## Guardrails
+
+- Never silently close or dismiss reviewer comments via the API. Always
+  leave an explanatory PR comment.
+- Never merge while reviewer comments are unresolved unless the user
+  explicitly authorises it.
+- Comments on files that this PR did not introduce (e.g., typos on a
+  branch but in lines that predate the PR) should still be flagged to the
+  user — but let the user decide whether to fix them here or open a
+  separate PR.
+- If Copilot's review times out or never arrives, report that fact instead
+  of silently proceeding.

--- a/.claude/skills/small-change/SKILL.md
+++ b/.claude/skills/small-change/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: small-change
+description: >
+  End-to-end workflow for implementing a small scoped change while preserving
+  every harness engineering invariant (dependency rules, tests, lint,
+  structural checks, boundary validation, docs, ADRs, quality grades,
+  versioning). Use for scoped single-domain tweaks that touch only a handful
+  of files: tightening a validation, correcting a config default, adjusting a
+  log line, updating a small piece of documented behavior, or making a narrow
+  non-bug behavior adjustment. Not for defect investigation or corrective bug
+  fixes (use `bug-fix`), not for multi-domain features (use `new-feature`),
+  not for behavior-preserving restructure (use `refactor`).
+metadata:
+  author: ai-landscape
+  version: 1.0.0
+  category: workflow
+---
+
+# Skill: Small Change
+
+Use this skill when the task is a **small, scoped non-bug change** that
+should land end-to-end in a single PR and must leave the repository in a state
+where every harness invariant is still green.
+
+## Core Rule
+
+A small change is not a license to skip harness gates. It is a license to
+make the gates cheap. Run every gate, but keep the diff tiny.
+
+## When to Use This Skill
+
+Use `small-change` when **all** of the following hold:
+- The change is confined to one domain and ideally one layer.
+- The diff will touch a handful of files (rule of thumb: ≤ 5 source files).
+- No new dependency, no new domain, no new architectural boundary.
+- The behavior change is narrow, intentional, and describable in one sentence.
+- The task is not a corrective bug fix for broken or regressed behavior.
+
+Route elsewhere when:
+- The task fixes broken, incorrect, or regressed behavior → use `bug-fix`.
+- The task introduces a new capability, endpoint, or service method → use `new-feature`.
+- The task restructures code without changing behavior → use `refactor`.
+- The task adds a new domain → use `add-domain`.
+
+## Harness Invariants To Preserve
+
+Every small change must leave the following green:
+
+| Invariant | Gate | How to check |
+|---|---|---|
+| Dependency direction (Types → Config → Repo → Service → Runtime → UI/API) | `npm run check:structure` (also runs inside `npm run build`) | Structural check script |
+| Type correctness | `npm run build` | TypeScript compile |
+| Lint + style | `npm run lint` | ESLint |
+| Behavior correctness | `npm run test` | Vitest suite |
+| Boundary validation | Code review | All external input parsed at boundary |
+| Docs ↔ code coherence | Manual check | See Step 5 |
+| Architecture decisions captured | Manual check | Add ADR only when a real decision is made |
+| Quality grade honesty | `docs/quality/QUALITY-GRADES.md` | Update if the change materially changes grade |
+| SonarCloud cleanliness | CI (post-merge) | Do not introduce new blocker/critical issues |
+| Versioning on master | `AGENTS.md` Default Rule #8 | Never commit to master without a semver tag |
+
+## Workflow
+
+### Step 1: Understand — Map The Blast Radius
+
+Before touching code:
+
+1. Read the task. Restate it in one sentence: *"Change X so that Y."*
+2. Identify the affected domain and layer from `docs/architecture/ARCHITECTURE.md`.
+3. Check `docs/quality/QUALITY-GRADES.md` for the affected area. A low grade means
+   extra care on tests and review.
+4. Skim `docs/design/PATTERNS.md` only if the change touches a pattern
+   (error handling, validation, logging, result types).
+5. Confirm the change is truly small per "When to Use This Skill." If not,
+   switch skills.
+
+Output: a one-line change statement plus the list of files you expect to edit.
+
+### Step 2: Plan — Smallest Correct Diff
+
+1. List files you will create or modify. Keep the list minimal.
+2. Decide test strategy:
+   - Small behavior change → one happy-path test plus one failure-path test
+     for the changed branch.
+   - Pure documentation or copy adjustment with no executable behavior change
+     → no new tests, but still run the full validation gates before submission.
+3. Decide doc strategy:
+   - Behavior visible at an API or config surface → update the relevant doc
+     in the same PR.
+   - Pure internal tweak invisible outside the module → no doc change needed.
+4. Decide ADR strategy:
+   - A new decision that future code must follow → write a minimal ADR in
+     `docs/context/DECISIONS.md`.
+   - Otherwise → no ADR.
+
+If any of these decisions feel unclear, ask before coding.
+
+### Step 3: Implement — Keep The Diff Tight
+
+1. Make the change in the layer that owns the behavior. Do not patch a
+   symptom one layer away.
+2. Respect dependency direction. If the change wants to import "to the right,"
+   stop and rethink — that is a structural signal, not a small change.
+3. Validate input at boundaries. Never pass raw JSON past a parse step.
+4. Write tests alongside the change, not after.
+5. Do not refactor unrelated code. File cleanup belongs in a separate PR via
+   the `refactor` skill.
+6. No commented-out code. No `TODO` without an issue ID.
+
+### Step 4: Validate — Run Every Gate
+
+Run locally, in this order, and stop on the first failure:
+
+```
+npm run lint
+npm run test
+npm run build    # includes npm run check:structure
+```
+
+Do not advance to Step 5 until all three are green. If a gate fails:
+- Diagnose the failure precisely. Do not suppress the rule or `eslint-disable` it.
+- Read any remediation hint printed by `check-dependencies.mjs` — it tells
+  you which layer move is legal.
+- If suppression is the only viable path, record the decision in
+  `docs/context/DECISIONS.md` and cite it in the PR.
+
+### Step 5: Review — Self-Review Against The Checklist
+
+Walk `docs/workflows/REVIEW-CHECKLIST.md`. Treat it as a hard checklist,
+not a suggestion. Pay particular attention to:
+
+- File length ≤ 300 lines, function length ≤ 30 lines.
+- Happy path AND one failure path tested.
+- No silent failures, no swallowed errors.
+- Error messages carry diagnostic context.
+- Secrets are not logged.
+- No new dependency without justification in the PR description.
+
+Then verify docs are still accurate:
+- Did the change alter a documented command, endpoint, config field, or
+  error surface? Update the owning doc.
+- Did the change materially affect a domain's risk profile? Update
+  `docs/quality/QUALITY-GRADES.md`.
+- Did a quoted example in docs reference the old behavior? Fix it.
+
+### Step 6: Submit — Clean Commit And PR
+
+1. Commit title prefix matches the change kind:
+   - Small public behavior adjustment → `feat: <imperative summary>`
+   - Internal non-user-facing adjustment → `chore: <imperative summary>`
+   - Doc-only → `docs: <imperative summary>`
+   - Test-only → `test: <imperative summary>`
+2. PR description includes:
+   - One-line change statement from Step 1.
+   - Affected domain(s) and layer(s).
+   - Motivation for the change.
+   - Gates run locally and passed.
+   - Any follow-up tasks identified but intentionally not done.
+3. **Never commit to `master` without bumping to a valid semver tag** (see
+   `AGENTS.md` Default Rule #8). Use the normal PR flow.
+4. If SonarCloud flags new issues after CI, fix them before merge. Use the
+   `sonar` skill to triage severity.
+
+## Examples
+
+**Example 1: Tighten a config default**
+
+Task: "Make the default command timeout 30 seconds instead of 60."
+
+Action:
+1. One-line statement: *"Change the default command timeout in command-gateway config from 60s to 30s."*
+2. Files: the Config layer module that defines the default; the test that
+   asserts defaults.
+3. Implement: change the constant, update the default assertion.
+4. Validate: `npm run lint && npm run test && npm run build` — all green.
+5. Docs: if the default is documented in `README.md` or a config doc, update it.
+6. PR title: `chore(command-gateway): lower default command timeout to 30s`.
+
+**Example 2: Tighten a non-bug rule interpretation**
+
+Task: "Treat an omitted optional `reason` field as `manual-review` in approval audit entries."
+
+Action:
+1. Restate: *"Default missing approval audit reasons to `manual-review`."*
+2. Plan: one happy-path test for the defaulting branch and one explicit-value test.
+3. Implement: apply the default in the owning layer instead of at every caller.
+4. Validate: full suite green; structure check green.
+5. Docs: update the audit-entry semantics if they are documented.
+6. PR title: `chore(approval-audit): default missing reasons to manual-review`.
+
+**Example 3: Adjust an API response shape intentionally**
+
+Task: "Include `requestId` in successful status responses from the admin API."
+
+Action:
+1. Restate: *"Add `requestId` to the admin API status response payload."*
+2. Plan: one integration test asserting the response shape.
+3. Implement: shape the response in the UI/API layer. Do not change service logic.
+4. Validate: all gates green.
+5. Docs: update the public API doc if the response shape is documented.
+6. PR title: `feat(platform-api): include requestId in status responses`.
+
+## Troubleshooting
+
+**Question: The structure check fails with "cannot import."**
+
+The change is trying to cross a layer boundary. Do not add a structural
+exception. Either move the needed symbol to a legal layer, or route the
+dependency through an existing public seam. Read the remediation message the
+script prints — it names the legal path.
+
+**Question: A test that I did not touch is now failing.**
+
+Treat that as a signal that the change reaches further than intended.
+Re-examine the design assumption behind the change. Do not "fix" the unrelated test by rewriting its
+assertion.
+
+**Question: The diff is growing past five files.**
+
+Stop. You are no longer doing a small change. Switch to `new-feature` or
+`refactor`, or split the work into a building block that ships first.
+
+**Question: A reviewer (or SonarCloud) flags a pre-existing issue in a file I
+edited.**
+
+Record it as a follow-up task in the PR description. Do not bundle unrelated
+cleanup into a small change — it defeats the review-speed advantage.
+
+**Question: The change needs a new npm dependency.**
+
+It is not a small change anymore. New dependencies deserve a separate,
+justified PR with an ADR.
+
+## Guardrails
+
+- Never suppress a linter, structural, or type error to force the change through.
+- Never skip `npm run lint`, `npm run test`, or `npm run build` before submission.
+- Never edit files outside the declared scope. If you find an unrelated issue,
+  file it as a follow-up.
+- Never commit on `master` without a semver tag.
+- Never mix a bug fix, refactor, or new feature into a small change PR.
+
+## See Also
+
+- `AGENTS.md` — repository invariants and skill routing
+- `docs/workflows/TASK-LIFECYCLE.md` — the underlying six-phase lifecycle
+- `docs/workflows/REVIEW-CHECKLIST.md` — the review rubric this skill enforces
+- `docs/architecture/DEPENDENCY-RULES.md` — layer rules the structure check enforces
+- `docs/design/PATTERNS.md` — preferred patterns for validation, errors, logging
+- `.claude/skills/bug-fix/SKILL.md` — for reproduction-first defect fixes
+- `.claude/skills/new-feature/SKILL.md` — for larger additive work
+- `.claude/skills/refactor/SKILL.md` — for behavior-preserving restructure
+- `.claude/skills/sonar/SKILL.md` — when SonarCloud flags post-merge issues

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
 5. Enforce important rules mechanically with CI, linting, structural tests, or scripts.
 6. When behavior, process, or architecture changes, update the repository documentation in the same change.
 7. Tool-specific files must not redefine repository policy. They are adapters, not alternate sources of truth.
-8. Never commit on master without a semver tag to handle versioning. SEMVER tag are with x.y.z format, no v prefix.
+8. Never commit on master without a semver tag to handle versioning. Semver tags must use the `x.y.z` format with no `v` prefix.
 
 ## Shared Engineering Invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@
 5. Enforce important rules mechanically with CI, linting, structural tests, or scripts.
 6. When behavior, process, or architecture changes, update the repository documentation in the same change.
 7. Tool-specific files must not redefine repository policy. They are adapters, not alternate sources of truth.
+8. Never commit on master without a semver tag to handle versioning. SEMVER tag are with x.y.z format, no v prefix.
 
 ## Shared Engineering Invariants
 
@@ -82,6 +83,7 @@ They live in `.claude/skills/` as the single source of truth.
 | Skill | Purpose | Location |
 |---|---|---|
 | `new-feature` | End-to-end workflow for adding a feature | [.claude/skills/new-feature/SKILL.md](.claude/skills/new-feature/SKILL.md) |
+| `small-change` | End-to-end workflow for a scoped non-bug change, preserving all harness invariants | [.claude/skills/small-change/SKILL.md](.claude/skills/small-change/SKILL.md) |
 | `bug-fix` | Structured workflow for reproducing and fixing bugs | [.claude/skills/bug-fix/SKILL.md](.claude/skills/bug-fix/SKILL.md) |
 | `refactor` | Safe refactoring with preservation guarantees | [.claude/skills/refactor/SKILL.md](.claude/skills/refactor/SKILL.md) |
 | `add-domain` | Bootstrap a new domain scaffold | [.claude/skills/add-domain/SKILL.md](.claude/skills/add-domain/SKILL.md) |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ git push origin main
 
 ### POST /api/v1/execute
 
-Execute a command. Async by default (returns requestId).
+Execute a command. The endpoint is synchronous: it blocks until the command
+reaches a terminal state (approved + executed, denied, or approval timed out)
+and returns the full result in a single response.
 
 ```bash
 curl -X POST http://localhost:3001/api/v1/execute \
@@ -103,25 +105,13 @@ curl -X POST http://localhost:3001/api/v1/execute \
   -d '{"command":"git status"}'
 ```
 
-Response (async, default):
-```json
-{ "requestId": "uuid", "status": "pending_approval" }
-```
-
-Response (sync, `?sync=true`):
+Success response:
 ```json
 { "requestId": "uuid", "status": "completed", "exitCode": 0, "stdout": "...", "stderr": "", "durationMs": 42 }
 ```
 
-### GET /api/v1/status/:requestId
-
-Poll for result (requires same API key).
-
-```json
-{ "requestId": "uuid", "status": "completed", "exitCode": 0, "stdout": "...", "durationMs": 42 }
-```
-
-Status values: `pending_approval`, `approved`, `denied`, `executing`, `completed`, `failed`, `timed_out`, `expired`
+Status values observable on success/failure paths: `completed`, `failed`,
+`denied`, `timed_out`.
 
 ### Error responses
 
@@ -130,7 +120,11 @@ All errors return:
 { "code": "ERROR_CODE", "message": "Human readable", "retryable": true }
 ```
 
-Codes: `MISSING_API_KEY`, `INVALID_API_KEY`, `IP_NOT_ALLOWED`, `RATE_LIMITED`, `COMMAND_DENIED`, `COMMAND_TOO_LONG`, `APPROVAL_TIMEOUT`, `APPROVAL_ERROR`
+Codes: `MISSING_API_KEY`, `INVALID_API_KEY`, `IP_NOT_ALLOWED`, `RATE_LIMITED`,
+`COMMAND_DENIED`, `COMMAND_TOO_LONG`, `INVALID_CWD`, `DENIED`,
+`DUPLICATE_IN_FLIGHT` (an identical command from this API key is already
+awaiting approval — retry after it settles), `APPROVAL_TIMEOUT`,
+`APPROVAL_ERROR`.
 
 ## CLI
 

--- a/docs/architecture/DOMAIN-BOUNDARIES.md
+++ b/docs/architecture/DOMAIN-BOUNDARIES.md
@@ -36,7 +36,7 @@
 - **Bounded context**: API key validation, command-rules matching, risk analysis, SQLite approval/audit storage, Telegram bot integration, optional admin approval UI, child process execution.
 - **Published events**: None (approval decisions stored in SQLite, audit log appended).
 - **Consumed events**: Telegram callback queries and admin UI approval decisions.
-- **Public API surface**: `POST /api/v1/execute`, `GET /api/v1/status/:requestId`, and when enabled `GET /admin/approvals`, `GET /api/v1/admin/approvals/pending`, `POST /api/v1/admin/approvals/stream-ticket`, `GET /api/v1/admin/approvals/stream`, `POST /api/v1/admin/approvals/:requestId/decide`.
+- **Public API surface**: `POST /api/v1/execute`, and when enabled `GET /admin/approvals`, `GET /api/v1/admin/approvals/pending`, `POST /api/v1/admin/approvals/stream-ticket`, `GET /api/v1/admin/approvals/stream`, `POST /api/v1/admin/approvals/:requestId/decide`.
 - **Data ownership**: SQLite database in the configured `dataDir` for approvals and audit log; in-memory pending request store; operator-owned JSON config files (`lucifer.json`, `api-keys.json`, `command-rules.json`).
 - **Key interfaces**: `ApprovalChannel` abstracts Telegram, web admin, multi-channel fan-out, and auto-approve development mode.
 
@@ -44,8 +44,7 @@
 
 | Source Domain | Target Domain | Mechanism | Contract Location |
 |---|---|---|---|
-| External caller | `command-gateway` | HTTP POST `/api/v1/execute` | Request: `{ command, cwd? }` + `x-api-key` header; Response: `ExecutionResult` |
-| External caller | `command-gateway` | HTTP GET `/api/v1/status/:requestId` | Response: `{ requestId, status, stdout?, stderr?, exitCode? }` |
+| External caller | `command-gateway` | HTTP POST `/api/v1/execute` | Request: `{ command, cwd? }` + `x-api-key` header; Response: `ExecutionResult` (synchronous — blocks until terminal state). Duplicate in-flight commands return `409 DUPLICATE_IN_FLIGHT`. |
 | Admin operator | `command-gateway` | Bearer-authenticated HTTP + SSE | Admin approval routes in `server/src/domains/command-gateway/api/register_approval_routes.ts` |
 | `command-gateway` | Telegram Bot API | HTTPS (telegraf) | Inline keyboard messages + callback queries |
 | `command-gateway` | SQLite | `better-sqlite3` | `<dataDir>/lucifer.db` (approvals + audit log tables) |

--- a/docs/specs/USER-JOURNEYS.md
+++ b/docs/specs/USER-JOURNEYS.md
@@ -58,10 +58,10 @@ The stories define what "done" means. Tests prove it.
 
 | ID | Story | Acceptance Criteria | Coverage |
 |---|---|---|---|
-| J2-S1 | As an AI Agent, I submit a command with a valid API key so that it enters the execution pipeline | `POST /api/v1/execute` with valid `x-api-key` returns `202` with a `requestId` | `covered` — `register_execute_routes.test.ts` |
+| J2-S1 | As an AI Agent, I submit a command with a valid API key so that it enters the execution pipeline | `POST /api/v1/execute` with valid `x-api-key` is accepted and its terminal result is returned in the same response | `covered` — `register_execute_routes.test.ts` |
 | J2-S2 | As an AI Agent, I submit an `always_approve` command so that it executes immediately without human approval | Command matching an `always_approve` rule executes and returns the result without prompting any approval channel | `covered` — `match_command_rule.test.ts`, `register_execute_routes.test.ts` |
-| J2-S3 | As an AI Agent, I poll for status so that I can retrieve async results | `GET /api/v1/status/:requestId` returns the current state (`pending_approval`, `executing`, `completed`, `failed`) | `covered` — `register_execute_routes.test.ts` |
-| J2-S4 | As an AI Agent, I use sync mode so that I get the result in a single request/response | `POST /api/v1/execute?sync=true` blocks until the command completes or is denied, then returns the full result | `covered` — `telegram-e2e.test.ts` |
+| J2-S3 | As an AI Agent, I get the full execution result in a single request/response | `POST /api/v1/execute` blocks until the command completes, is denied, or approval times out, then returns the full result | `covered` — `telegram-e2e.test.ts`, `register_execute_routes.test.ts` |
+| J2-S4 | As an AI Agent, I retry politely when a duplicate command is already awaiting approval | A duplicate in-flight command from the same API key is rejected with `409 DUPLICATE_IN_FLIGHT` and marked retryable | `covered` — `register_execute_routes.test.ts` |
 | J2-S5 | As an AI Agent, I submit a command with an optional `cwd` so that execution happens in a specific directory | Absolute `cwd` is validated and passed to the child process | `covered` — `execute_command.test.ts` |
 
 ---
@@ -78,7 +78,7 @@ The stories define what "done" means. Tests prove it.
 | J3-S1 | As an Approver, I receive a Telegram message with the command details and inline approval buttons | Bot sends a message containing the command text, risk info, and 7 buttons (1 once + 3 exact + 2 prefix + 1 deny) | `covered` — `telegram-e2e.test.ts`, `request_telegram_approval.test.ts` |
 | J3-S2 | As an Approver, I press an exact-approval button so that only this specific command is approved | Exact approval stores the full command string; the command executes and completes | `covered` — `telegram-e2e.test.ts` |
 | J3-S3 | As an Approver, I press a prefix-approval button so that similar commands are also approved | Prefix approval stores the first two tokens; subsequent commands with the same prefix auto-approve from cache | `covered` — `telegram-e2e.test.ts` |
-| J3-S4 | As an Approver, I press the deny button so that the command is rejected | The request transitions to `denied`; the AI Agent sees status `denied` | `covered` — `telegram-e2e.test.ts` |
+| J3-S4 | As an Approver, I press the deny button so that the command is rejected | The AI Agent's blocked POST resolves with `403` / `status: denied` | `covered` — `telegram-e2e.test.ts` |
 | J3-S5 | As an Approver, I press a permanent-approval button so that this command never asks again | Permanent exact approval is stored; same command auto-approves indefinitely | `covered` — `telegram-e2e.test.ts` |
 
 | J3-S6 | As an Approver, I press the "Approve Once" button so that this specific request executes but no cached approval is stored | The command executes successfully; repeating the same command requires a new approval | `covered` — `telegram-e2e.test.ts` ("deny and approve-once journey") |

--- a/docs/specs/command-execution.md
+++ b/docs/specs/command-execution.md
@@ -3,18 +3,16 @@
 ## Purpose
 
 Accept authenticated command requests, apply policy, obtain approval when
-needed, execute the command, and return or expose the result.
+needed, execute the command, and return the result.
 
 ## Entry Points
 
 - `POST /api/v1/execute`
-- `GET /api/v1/status/:requestId`
 
 ## Inputs
 
 - Header: `x-api-key`
 - Body: `{ command: string, cwd?: string }`
-- Query: `sync=true` for blocking approval/execution flow
 
 ## Core Behavior
 
@@ -25,20 +23,22 @@ needed, execute the command, and return or expose the result.
 - Matches the command against the first prefix rule in `command-rules.json`.
 - `always_deny` returns `403`.
 - `always_approve` executes immediately.
-- `manual_approve` checks cached approvals first, then requests approval.
+- `manual_approve` checks cached approvals first, then requests approval and
+  blocks the HTTP response until the approver decides or the approval times
+  out.
 
 ## Result States
 
-- `pending_approval`
-- `denied`
-- `executing`
 - `completed`
 - `failed`
+- `denied`
 - `timed_out`
 
 ## Notes
 
-- Async mode is the default.
-- Sync mode waits for approval and execution unless an identical request is
-  already pending.
-- Completed async results are cached in memory for a short time.
+- The endpoint is synchronous. There is no async / `?sync=true` /
+  `/status/:requestId` surface — the caller always receives the terminal
+  result (or a terminal error) on the original request.
+- If an identical command from the same API key is already awaiting approval,
+  the duplicate request is rejected with `409 DUPLICATE_IN_FLIGHT`; the caller
+  should retry once the first request settles.

--- a/server/src/cli.test.ts
+++ b/server/src/cli.test.ts
@@ -324,21 +324,34 @@ describe('First configuration journey', () => {
       expect(approvedRes.status).toBe(200);
       expect(approvedRes.body.status).toBe('completed');
 
-      // Step 6: Submit a command that goes to the web approval channel
-      const pendingRes = await request(result.app)
-        .post('/api/v1/execute')
-        .set('x-api-key', apiKey)
-        .send({ command: 'echo approve-me via web' });
-      expect(pendingRes.status).toBe(202);
-      const { requestId } = pendingRes.body;
+      // Step 6: Fire a manual-approve command without awaiting — the sync
+      // handler blocks until the admin UI decides. Call `.end(cb)` so the
+      // request is dispatched immediately instead of lazily on `.then()`.
+      const pendingPromise = new Promise<{ status: number; body: { status: string; exitCode: number; stdout: string } }>((resolveP, rejectP) => {
+        request(result.app)
+          .post('/api/v1/execute')
+          .set('x-api-key', apiKey)
+          .send({ command: 'echo approve-me via web' })
+          .end((err, res) => {
+            if (err) rejectP(err);
+            else resolveP(res);
+          });
+      });
 
-      // Step 7: Admin lists pending approvals using the generated admin secret
-      const pendingList = await request(result.app)
-        .get('/api/v1/admin/approvals/pending')
-        .set('Authorization', `Bearer ${adminSecret}`);
-      expect(pendingList.status).toBe(200);
-      expect(pendingList.body.pending.length).toBeGreaterThanOrEqual(1);
-      expect(pendingList.body.pending.some((p: { requestId: string }) => p.requestId === requestId)).toBe(true);
+      // Step 7: Wait until the admin UI sees the pending request
+      let requestId: string | undefined;
+      for (let i = 0; i < 40 && !requestId; i++) {
+        const pendingList = await request(result.app)
+          .get('/api/v1/admin/approvals/pending')
+          .set('Authorization', `Bearer ${adminSecret}`);
+        expect(pendingList.status).toBe(200);
+        const match = pendingList.body.pending.find(
+          (p: { command: string; requestId: string }) => p.command === 'echo approve-me via web',
+        );
+        if (match) requestId = match.requestId;
+        else await new Promise(r => setTimeout(r, 100));
+      }
+      expect(requestId).toBeDefined();
 
       // Step 8: Admin approves the command via the web decide endpoint
       const decideRes = await request(result.app)
@@ -349,15 +362,12 @@ describe('First configuration journey', () => {
       expect(decideRes.body.ok).toBe(true);
       expect(decideRes.body.decision).toBe('approved');
 
-      // Step 9: Poll status — command should now be completed
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      const statusRes = await request(result.app)
-        .get(`/api/v1/status/${requestId}`)
-        .set('x-api-key', apiKey);
-      expect(statusRes.status).toBe(200);
-      expect(statusRes.body.status).toBe('completed');
-      expect(statusRes.body.exitCode).toBe(0);
-      expect(statusRes.body.stdout).toContain('approve-me via web');
+      // Step 9: The original POST should resolve with the execution result
+      const pendingRes = await pendingPromise;
+      expect(pendingRes.status).toBe(200);
+      expect(pendingRes.body.status).toBe('completed');
+      expect(pendingRes.body.exitCode).toBe(0);
+      expect(pendingRes.body.stdout).toContain('approve-me via web');
     } finally {
       await result.stop();
     }

--- a/server/src/domains/command-gateway/api/register_execute_routes.test.ts
+++ b/server/src/domains/command-gateway/api/register_execute_routes.test.ts
@@ -88,15 +88,17 @@ describe('POST /api/v1/execute integration', () => {
     expect(res.body.code).toBe('COMMAND_DENIED');
   });
 
-  it('returns pending_approval for manual_approve command (async default)', async () => {
+  it('runs manual_approve command through the approval channel and returns its result', async () => {
+    // The integration test app uses the auto-approve channel, so a manual
+    // approve rule still resolves synchronously within the request.
     const res = await request(ctx.app)
       .post('/api/v1/execute')
       .set('x-api-key', ctx.testKey)
       .send({ command: 'git status' });
 
-    expect(res.status).toBe(202);
-    expect(res.body.status).toBe('pending_approval');
-    expect(res.body.requestId).toBeDefined();
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('completed');
+    expect(res.body.exitCode).toBe(0);
   });
 
   it('returns 400 for command exceeding max length', async () => {
@@ -129,43 +131,6 @@ describe('POST /api/v1/execute integration', () => {
     expect(res.status).toBe(200);
     expect(res.body.exitCode).toBe(1);
     expect(res.body.status).toBe('failed');
-  });
-});
-
-describe('GET /api/v1/status/:requestId', () => {
-  it('returns 401 for missing API key', async () => {
-    const res = await request(ctx.app).get('/api/v1/status/some-id');
-    expect(res.status).toBe(401);
-  });
-
-  it('returns 404 for unknown requestId', async () => {
-    const res = await request(ctx.app)
-      .get('/api/v1/status/nonexistent-id')
-      .set('x-api-key', ctx.testKey);
-
-    expect(res.status).toBe(404);
-    expect(res.body.code).toBe('NOT_FOUND');
-  });
-
-  it('returns status for a pending manual_approve request', async () => {
-    // First create a pending request
-    const execRes = await request(ctx.app)
-      .post('/api/v1/execute')
-      .set('x-api-key', ctx.testKey)
-      .send({ command: 'git log --oneline' });
-
-    expect(execRes.status).toBe(202);
-    const { requestId } = execRes.body;
-
-    // Poll for status (auto-approve runs async, might be completed or pending)
-    const statusRes = await request(ctx.app)
-      .get(`/api/v1/status/${requestId}`)
-      .set('x-api-key', ctx.testKey);
-
-    expect([200, 404]).toContain(statusRes.status);
-    if (statusRes.status === 200) {
-      expect(['pending_approval', 'executing', 'completed', 'failed'].includes(statusRes.body.status)).toBe(true);
-    }
   });
 });
 
@@ -285,18 +250,6 @@ describe('MockApprovalChannel integration', () => {
   let mockChannel: MockChannel;
   let db: Database.Database;
 
-  async function approveAndWaitForCompletion(requestId: string): Promise<void> {
-    await waitForCondition(() => mockChannel.pendingApprovals.size >= 1, 5000);
-    const [pendingId] = mockChannel.pendingApprovals.keys();
-    mockChannel.approveNext(pendingId);
-    await waitForCondition(async () => {
-      const statusRes = await request(mockApp)
-        .get(`/api/v1/status/${requestId}`)
-        .set('x-api-key', MOCK_KEY);
-      return statusRes.status === 200 && statusRes.body.status === 'completed';
-    }, 5000);
-  }
-
   beforeAll(() => {
     mkdirSync(MOCK_CONFIG_DIR, { recursive: true });
 
@@ -384,34 +337,33 @@ describe('MockApprovalChannel integration', () => {
     rmSync(MOCK_TEST_DIR, { recursive: true, force: true });
   });
 
-  it('async approve — approved command executes and result is retrievable', async () => {
-    // Submit command in async mode
-    const execRes = await request(mockApp)
-      .post('/api/v1/execute')
-      .set('x-api-key', MOCK_KEY)
-      .send({ command: 'git --version' });
+  it('approve — blocks until approved, then returns full execution result', async () => {
+    mockChannel.pendingApprovals.clear();
 
-    expect(execRes.status).toBe(202);
-    expect(execRes.body.status).toBe('pending_approval');
-    const { requestId } = execRes.body;
-
-    await approveAndWaitForCompletion(requestId);
-
-    // Verify final result
-    const statusRes = await request(mockApp)
-      .get(`/api/v1/status/${requestId}`)
-      .set('x-api-key', MOCK_KEY);
-
-    expect(statusRes.status).toBe(200);
-    expect(statusRes.body.status).toBe('completed');
-    expect(statusRes.body.exitCode).toBe(0);
-    expect(statusRes.body.stdout).toContain('git version');
-  }, 15_000);
-
-  it('sync deny — blocks until denied, then returns 403', async () => {
     const [res] = await Promise.all([
       request(mockApp)
-        .post('/api/v1/execute?sync=true')
+        .post('/api/v1/execute')
+        .set('x-api-key', MOCK_KEY)
+        .send({ command: 'git --version' }),
+      (async () => {
+        await waitForCondition(() => mockChannel.pendingApprovals.size >= 1, 5000);
+        const [pendingId] = mockChannel.pendingApprovals.keys();
+        mockChannel.approveNext(pendingId);
+      })(),
+    ]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('completed');
+    expect(res.body.exitCode).toBe(0);
+    expect(res.body.stdout).toContain('git version');
+  }, 15_000);
+
+  it('deny — blocks until denied, then returns 403', async () => {
+    mockChannel.pendingApprovals.clear();
+
+    const [res] = await Promise.all([
+      request(mockApp)
+        .post('/api/v1/execute')
         .set('x-api-key', MOCK_KEY)
         .send({ command: 'git log --oneline' }),
       (async () => {
@@ -426,40 +378,54 @@ describe('MockApprovalChannel integration', () => {
     expect(res.body.status).toBe('denied');
   }, 15_000);
 
-  it('sync timeout — returns 408 when approval times out', async () => {
+  it('timeout — returns 408 when approval times out', async () => {
     // Uses timeoutApp which has a 1-second approval timeout
     const res = await request(timeoutApp)
-      .post('/api/v1/execute?sync=true')
+      .post('/api/v1/execute')
       .set('x-api-key', MOCK_KEY)
       .send({ command: 'git diff' });
 
-    // The approval timeout is 1 second, so this should return 408
     expect(res.status).toBe(408);
     expect(res.body.code).toBe('APPROVAL_TIMEOUT');
     expect(res.body.retryable).toBe(true);
   }, 10_000);
 
-  it('async mode — returns 202 with pending status, then resolves after approval', async () => {
-    const execRes = await request(mockApp)
+  it('duplicate in-flight command returns 409 without raising a second approval prompt', async () => {
+    mockChannel.pendingApprovals.clear();
+
+    // Use `.end(cb)` so the first request is dispatched immediately rather
+    // than lazily when awaited; otherwise the duplicate check below never
+    // sees a pending entry.
+    const firstRequest = new Promise<{ status: number; body: { status: string } }>((resolveR, rejectR) => {
+      request(mockApp)
+        .post('/api/v1/execute')
+        .set('x-api-key', MOCK_KEY)
+        .send({ command: 'git remote -v' })
+        .end((err, res) => err ? rejectR(err) : resolveR(res));
+    });
+
+    // Wait until the first request is parked at the approval channel so the
+    // second call observes the duplicate in the pending store.
+    await waitForCondition(() => mockChannel.pendingApprovals.size >= 1, 5000);
+
+    const dupRes = await request(mockApp)
       .post('/api/v1/execute')
       .set('x-api-key', MOCK_KEY)
-      .send({ command: 'git branch' });
+      .send({ command: 'git remote -v' });
 
-    expect(execRes.status).toBe(202);
-    expect(execRes.body.status).toBe('pending_approval');
-    expect(execRes.body.requestId).toBeDefined();
+    expect(dupRes.status).toBe(409);
+    expect(dupRes.body.code).toBe('DUPLICATE_IN_FLIGHT');
+    expect(dupRes.body.retryable).toBe(true);
 
-    const { requestId } = execRes.body;
+    // Still exactly one pending approval — the dup never reached the channel.
+    expect(mockChannel.pendingApprovals.size).toBe(1);
 
-    await approveAndWaitForCompletion(requestId);
-
-    // Final status check
-    const statusRes = await request(mockApp)
-      .get(`/api/v1/status/${requestId}`)
-      .set('x-api-key', MOCK_KEY);
-
-    expect(statusRes.status).toBe(200);
-    expect(statusRes.body.status).toBe('completed');
+    // Let the first request finish cleanly.
+    const [pendingId] = mockChannel.pendingApprovals.keys();
+    mockChannel.approveNext(pendingId);
+    const firstRes = await firstRequest;
+    expect(firstRes.status).toBe(200);
+    expect(firstRes.body.status).toBe('completed');
   }, 15_000);
 
   it('existing approval skips the approval channel', async () => {
@@ -471,7 +437,7 @@ describe('MockApprovalChannel integration', () => {
     mockChannel.pendingApprovals.clear();
 
     const res = await request(mockApp)
-      .post('/api/v1/execute?sync=true')
+      .post('/api/v1/execute')
       .set('x-api-key', MOCK_KEY)
       .send({ command: 'git version' });
 

--- a/server/src/domains/command-gateway/api/register_execute_routes.ts
+++ b/server/src/domains/command-gateway/api/register_execute_routes.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { Router, Request, Response } from 'express';
 import type {
-  ApprovalChannel, ExecutionResult, RequestStatus, ErrorResponse, LuciferConfig,
+  ApprovalChannel, RequestStatus, ErrorResponse, LuciferConfig,
 } from '../types/command_types.js';
 import type { ApiKeyStore, CommandRulesStore, ApprovalStore, PendingRequestStore, AuditLog } from '../types/store_interfaces.js';
 import { authenticateRequest, createRateLimiter } from '../service/authenticate_request.js';
@@ -10,23 +10,6 @@ import { executeCommand } from '../service/execute_command.js';
 import { createChildLogger } from '../../../lib/logger.js';
 
 const log = createChildLogger('routes');
-
-interface CompletedResult {
-  result: ExecutionResult;
-  completedAt: number;
-}
-
-const completedResults = new Map<string, CompletedResult>();
-
-// Clean up completed results older than 10 minutes
-setInterval(() => {
-  const cutoff = Date.now() - 10 * 60_000;
-  for (const [id, entry] of completedResults.entries()) {
-    if (entry.completedAt < cutoff) {
-      completedResults.delete(id);
-    }
-  }
-}, 60_000);
 
 interface ValidationError {
   statusCode: number;
@@ -96,7 +79,6 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
 
     const requestId = randomUUID();
     const apiKeyName = authResult.keyConfig.name;
-    const isSync = req.query.sync === 'true';
 
     auditLog.append({
       ts: new Date().toISOString(),
@@ -187,46 +169,15 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
 
     log.info({ requestId, command, ip }, 'Command requires manual approval, forwarding to approval channel');
 
-    // Coalesce: check if same command from same key is already pending
-    const existingPending = pendingStore.findByCommand(command, apiKeyName);
-
-    if (!isSync) {
-      // Async mode (default): return requestId, process in background
-      if (!existingPending) {
-        pendingStore.add({
-          requestId,
-          command,
-          apiKeyName,
-          ip,
-          createdAt: new Date().toISOString(),
-          resolve: () => {},
-          reject: () => {},
-          abortController,
-        });
-
-        // Fire and forget the approval request + execution
-        processApprovalAsync({
-          requestId, command, apiKeyName, ip, cwd, riskAnalysis,
-          config, approvalChannel, pendingStore, auditLog, abortController,
-        });
-      }
-
-      res.status(202).json({
-        requestId: existingPending?.requestId ?? requestId,
-        status: 'pending_approval' as RequestStatus,
-      });
-      return;
-    }
-
-    // Sync mode: block until decision
-    if (existingPending) {
-      // Wait for the existing pending request to resolve
-      // For simplicity in sync mode, just wait for a bit then poll
-      res.status(202).json({
-        requestId: existingPending.requestId,
-        status: 'pending_approval' as RequestStatus,
-        message: 'Another request for the same command is pending. Poll for status.',
-      });
+    // Reject an identical in-flight command from the same API key. Two parallel
+    // approval prompts for the same command would confuse the human approver;
+    // the second caller should retry after the first one settles.
+    if (pendingStore.findByCommand(command, apiKeyName)) {
+      res.status(409).json({
+        code: 'DUPLICATE_IN_FLIGHT',
+        message: 'An identical command from this API key is already awaiting approval. Retry after it settles.',
+        retryable: true,
+      } satisfies ErrorResponse);
       return;
     }
 
@@ -242,7 +193,12 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
         abortController,
       });
 
-      req.on('close', () => {
+      // Abort execution if the client disconnects before we finish writing
+      // the response. `res.on('close')` fires for both premature disconnects
+      // and normal completion, so we gate on `res.writableEnded` to ignore
+      // the normal-completion case.
+      res.on('close', () => {
+        if (res.writableEnded) return;
         abortController.abort();
         pendingStore.remove(requestId);
       });
@@ -259,7 +215,7 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
           requestId,
           status: 'denied' as RequestStatus,
           code: 'DENIED',
-          message: 'Command was denied via Telegram',
+          message: 'Command was denied',
           retryable: false,
         });
         return;
@@ -291,7 +247,7 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
           requestId,
           status: 'timed_out' as RequestStatus,
           code: 'APPROVAL_TIMEOUT',
-          message: 'Approval timed out. No response from Telegram.',
+          message: 'Approval timed out. No response from approver.',
           retryable: true,
         });
       } else {
@@ -306,123 +262,4 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
       pendingStore.remove(requestId);
     }
   });
-
-  router.get('/api/v1/status/:requestId', (req: Request, res: Response) => {
-    const requestId = Array.isArray(req.params.requestId) ? req.params.requestId[0] : req.params.requestId;
-
-    // Auth check: require valid API key for status queries
-    const rawKey = req.headers['x-api-key'] as string | undefined;
-    const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() ?? req.socket.remoteAddress ?? 'unknown';
-    const authResult = authenticateRequest(apiKeyStore, rateLimiter, rawKey, ip);
-    if (!authResult.ok) {
-      res.status(authResult.statusCode).json(authResult.error);
-      return;
-    }
-
-    // Check completed results cache
-    const completed = completedResults.get(requestId);
-    if (completed) {
-      res.json(completed.result);
-      return;
-    }
-
-    // Check pending store
-    const pending = pendingStore.get(requestId);
-    if (pending) {
-      // Scope check: only the same API key can query status
-      if (pending.apiKeyName !== authResult.keyConfig.name) {
-        res.status(404).json({
-          code: 'NOT_FOUND',
-          message: 'Request not found',
-          retryable: false,
-        } satisfies ErrorResponse);
-        return;
-      }
-      res.json({ requestId, status: 'pending_approval' as RequestStatus });
-      return;
-    }
-
-    res.status(404).json({
-      code: 'NOT_FOUND',
-      message: 'Request not found or expired',
-      retryable: false,
-    } satisfies ErrorResponse);
-  });
-}
-
-interface ApprovalAsyncContext {
-  requestId: string;
-  command: string;
-  apiKeyName: string;
-  ip: string;
-  cwd: string | undefined;
-  riskAnalysis: ReturnType<typeof analyzeCommandRisk>;
-  config: LuciferConfig;
-  approvalChannel: ApprovalChannel;
-  pendingStore: PendingRequestStore;
-  auditLog: AuditLog;
-  abortController: AbortController;
-}
-
-async function processApprovalAsync(ctx: ApprovalAsyncContext): Promise<void> {
-  const { requestId, command, apiKeyName, ip, cwd, riskAnalysis, config, approvalChannel, pendingStore, auditLog, abortController } = ctx;
-  try {
-    const approvalResult = await Promise.race([
-      approvalChannel.requestApproval(command, apiKeyName, ip, requestId, riskAnalysis),
-      new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error('Approval timed out')), config.approvalTimeoutSeconds * 1000);
-      }),
-    ]);
-
-    if (approvalResult.decision === 'denied') {
-      completedResults.set(requestId, {
-        result: { requestId, status: 'denied' },
-        completedAt: Date.now(),
-      });
-      return;
-    }
-
-    // Bridge the gap between approval resolve (which removes from pendingStore)
-    // and execution completion so status polling never returns 404.
-    completedResults.set(requestId, {
-      result: { requestId, status: 'executing' },
-      completedAt: Date.now(),
-    });
-
-    const result = await executeCommand({
-      command,
-      requestId,
-      cwd,
-      timeoutMs: config.executionTimeoutSeconds * 1000,
-      maxOutputBytes: config.maxOutputBytes,
-      maxConcurrent: config.maxConcurrentExecutions,
-      abortSignal: abortController.signal,
-    });
-
-    auditLog.append({
-      ts: new Date().toISOString(),
-      type: 'executed',
-      requestId,
-      command,
-      exitCode: result.exitCode,
-      durationMs: result.durationMs,
-      error: result.error,
-    });
-
-    completedResults.set(requestId, { result, completedAt: Date.now() });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    log.error({ requestId, err: message }, 'Async approval/execution failed');
-
-    completedResults.set(requestId, {
-      result: {
-        requestId,
-        status: message.includes('timed out') ? 'timed_out' : 'failed',
-        error: message,
-      },
-      completedAt: Date.now(),
-    });
-  } finally {
-    pendingStore.remove(requestId);
-  }
 }

--- a/server/src/domains/command-gateway/api/register_execute_routes.ts
+++ b/server/src/domains/command-gateway/api/register_execute_routes.ts
@@ -169,9 +169,12 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
 
     log.info({ requestId, command, ip }, 'Command requires manual approval, forwarding to approval channel');
 
-    // Reject an identical in-flight command from the same API key. Two parallel
-    // approval prompts for the same command would confuse the human approver;
-    // the second caller should retry after the first one settles.
+    // Reject an identical command from the same API key that is still
+    // awaiting an approval decision — two parallel prompts for the same
+    // command would confuse the human approver. The pendingStore entry is
+    // cleared as soon as a decision is reached (below), so this gate does
+    // NOT apply while an approved command is executing; a concurrent caller
+    // will fall through to the normal `findApproval` cached-approval path.
     if (pendingStore.findByCommand(command, apiKeyName)) {
       res.status(409).json({
         code: 'DUPLICATE_IN_FLIGHT',
@@ -208,7 +211,28 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
         new Promise<never>((_, reject) => {
           setTimeout(() => reject(new Error('Approval timed out')), config.approvalTimeoutSeconds * 1000);
         }),
+        // Bail out of the approval wait if the client disconnected. Otherwise
+        // the handler would continue awaiting the channel until either the
+        // approver acts or the approval timeout fires — orphaning work that
+        // nobody is listening for.
+        new Promise<never>((_, reject) => {
+          if (abortController.signal.aborted) {
+            reject(new Error('Request aborted'));
+            return;
+          }
+          abortController.signal.addEventListener(
+            'abort',
+            () => reject(new Error('Request aborted')),
+            { once: true },
+          );
+        }),
       ]);
+
+      // Approval decision obtained — release the pending-store slot now so
+      // DUPLICATE_IN_FLIGHT only gates *awaiting-approval* duplicates and
+      // not in-flight execution. `release` (unlike `remove`) does not abort
+      // the live AbortController, which still guards the upcoming execution.
+      pendingStore.release(requestId);
 
       if (approvalResult.decision === 'denied') {
         res.status(403).json({
@@ -242,7 +266,12 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
       res.json(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
-      if (message.includes('timed out')) {
+      if (message.includes('aborted')) {
+        // Client disconnected before a decision landed. Ask the channel to
+        // clean up any bot message / admin queue entry. No response to send.
+        try { approvalChannel.cancel?.(requestId); } catch { /* best-effort */ }
+        log.info({ requestId }, 'Approval wait aborted by client disconnect');
+      } else if (message.includes('timed out')) {
         res.status(408).json({
           requestId,
           status: 'timed_out' as RequestStatus,

--- a/server/src/domains/command-gateway/contracts/schema_contracts.test.ts
+++ b/server/src/domains/command-gateway/contracts/schema_contracts.test.ts
@@ -104,33 +104,6 @@ describe('API response contracts', () => {
     `);
   });
 
-  it('PendingApproval shape on 202', async () => {
-    const res = await request(ctx.app)
-      .post('/api/v1/execute')
-      .set('x-api-key', ctx.testKey)
-      .send({ command: 'git status' });
-    expect(res.status).toBe(202);
-    expect(shapeOf(res.body)).toMatchInlineSnapshot(`
-      {
-        "requestId": "string",
-        "status": "string",
-      }
-    `);
-  });
-
-  it('StatusNotFound shape on 404', async () => {
-    const res = await request(ctx.app)
-      .get('/api/v1/status/nonexistent')
-      .set('x-api-key', ctx.testKey);
-    expect(res.status).toBe(404);
-    expect(shapeOf(res.body)).toMatchInlineSnapshot(`
-      {
-        "code": "string",
-        "message": "string",
-        "retryable": "boolean",
-      }
-    `);
-  });
 });
 
 // --- Group 2: SQLite roundtrip contracts ---

--- a/server/src/domains/command-gateway/repository/pending_request_store.test.ts
+++ b/server/src/domains/command-gateway/repository/pending_request_store.test.ts
@@ -77,6 +77,23 @@ describe('PendingRequestStore', () => {
     });
   });
 
+  describe('release', () => {
+    it('deletes request WITHOUT aborting the abortController', () => {
+      const request = createTestRequest();
+      const abortSpy = vi.spyOn(request.abortController, 'abort');
+      store.add(request);
+
+      store.release('req-1');
+
+      expect(store.get('req-1')).toBeUndefined();
+      expect(abortSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when releasing a non-existent request', () => {
+      expect(() => store.release('nonexistent')).not.toThrow();
+    });
+  });
+
   describe('findByCommand', () => {
     it('returns matching request with same command and apiKeyName', () => {
       const request = createTestRequest();

--- a/server/src/domains/command-gateway/repository/pending_request_store.ts
+++ b/server/src/domains/command-gateway/repository/pending_request_store.ts
@@ -7,7 +7,11 @@ export interface PendingRequestStore {
   add(request: PendingRequest): void;
   resolve(requestId: string, decision: ApprovalDecision): boolean;
   get(requestId: string): PendingRequest | undefined;
+  /** Remove the entry AND abort its abortController (cancel/cleanup). */
   remove(requestId: string): void;
+  /** Remove the entry WITHOUT aborting the abortController. Use when
+   *  handing off from approval-wait to execution. */
+  release(requestId: string): void;
   findByCommand(command: string, apiKeyName: string): PendingRequest | undefined;
   cleanup(maxAgeMs: number): number;
   size(): number;
@@ -44,6 +48,10 @@ export function createPendingRequestStore(): PendingRequestStore {
         pending.abortController.abort();
         store.delete(requestId);
       }
+    },
+
+    release(requestId: string): void {
+      store.delete(requestId);
     },
 
     findByCommand(command: string, apiKeyName: string): PendingRequest | undefined {

--- a/server/src/domains/command-gateway/types/store_interfaces.ts
+++ b/server/src/domains/command-gateway/types/store_interfaces.ts
@@ -27,7 +27,12 @@ export interface PendingRequestStore {
   add(request: import('./command_types.js').PendingRequest): void;
   resolve(requestId: string, decision: import('./command_types.js').ApprovalDecision): boolean;
   get(requestId: string): import('./command_types.js').PendingRequest | undefined;
+  /** Remove the entry AND abort its abortController (used for cancels/cleanup). */
   remove(requestId: string): void;
+  /** Remove the entry without touching its abortController. Use this when the
+   *  waiter has successfully handed off to execution — we want to free the
+   *  DUPLICATE_IN_FLIGHT slot but NOT abort the live command. */
+  release(requestId: string): void;
   findByCommand(command: string, apiKeyName: string): import('./command_types.js').PendingRequest | undefined;
   cleanup(maxAgeMs: number): number;
   size(): number;

--- a/server/src/test/telegram-e2e.test.ts
+++ b/server/src/test/telegram-e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import request from 'supertest';
+import type { Response } from 'supertest';
 import { spawn } from 'node:child_process';
 import { readFileSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -9,7 +10,6 @@ import {
   waitForBotMessage,
   getBotMessages,
   pressInlineButton,
-  waitForCondition,
   TEST_BOT_TOKEN,
   TEST_CHAT_ID,
   type TelegramE2EContext,
@@ -69,41 +69,44 @@ function extractInlineButtons(botMessages: BotMessageResult): ButtonInfo[] {
 }
 
 /**
- * Helper: submit command, wait for bot message, extract buttons.
+ * Fire POST /api/v1/execute immediately and return a real Promise for the
+ * response. The sync-only handler only responds once Telegram decides, so
+ * tests need to inspect the bot buffer and press a button before the
+ * promise resolves. We explicitly call `.end(cb)` so the request is sent
+ * right away rather than waiting for the caller to `.then()` the supertest
+ * Test object (which would deadlock the bot-message wait below).
  */
-async function submitAndGetButtons(command: string) {
-  const execRes = await request(ctx.app)
-    .post('/api/v1/execute')
-    .set('x-api-key', ctx.testKey)
-    .send({ command });
+function fireExecute(context: TelegramE2EContext, command: string): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    request(context.app)
+      .post('/api/v1/execute')
+      .set('x-api-key', context.testKey)
+      .send({ command })
+      .end((err, res) => {
+        if (err) reject(err);
+        else resolve(res);
+      });
+  });
+}
 
-  expect(execRes.status).toBe(202);
-  const { requestId } = execRes.body;
-
+/**
+ * Helper: fire the request, wait for the bot message, extract buttons.
+ * Returns the unawaited POST promise so the caller can press a button and
+ * then await the final response.
+ */
+async function fireAndGetButtons(command: string) {
+  const execPromise = fireExecute(ctx, command);
   await waitForBotMessage(ctx);
   const updates = await getBotMessages(ctx) as any as BotMessageResult;
   const buttons = extractInlineButtons(updates);
   const lastMsg = updates.result.at(-1);
-
-  return { requestId, buttons, lastMsg, updates };
-}
-
-/**
- * Helper: wait for a request to reach a terminal status.
- */
-async function waitForStatus(requestId: string, expectedStatus: string, timeoutMs = 10_000) {
-  await waitForCondition(async () => {
-    const statusRes = await request(ctx.app)
-      .get(`/api/v1/status/${requestId}`)
-      .set('x-api-key', ctx.testKey);
-    return statusRes.status === 200 && statusRes.body.status === expectedStatus;
-  }, timeoutMs);
+  return { execPromise, buttons, lastMsg, updates };
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 describe('Telegram E2E: approval flow', () => {
   it('sends approval request to Telegram when command requires manual_approve', async () => {
-    const { buttons, lastMsg } = await submitAndGetButtons('git status');
+    const { execPromise, buttons, lastMsg } = await fireAndGetButtons('git status');
 
     // The message should contain the command
     expect(lastMsg.message.text).toContain('git status');
@@ -113,10 +116,15 @@ describe('Telegram E2E: approval flow', () => {
     expect(buttons.length).toBe(7);
     expect(buttons.some(b => b.text.includes('Exact 2h'))).toBe(true);
     expect(buttons.some(b => b.text.includes('Deny'))).toBe(true);
+
+    // Clean up: deny so the POST resolves
+    const denyBtn = buttons.find(b => b.callback_data.startsWith('deny:'))!;
+    await pressInlineButton(ctx, denyBtn.callback_data, denyBtn.messageId);
+    await execPromise;
   }, 15_000);
 
   it('approves command via exact-2h button and executes it', async () => {
-    const { requestId, buttons } = await submitAndGetButtons('git --version');
+    const { execPromise, buttons } = await fireAndGetButtons('git --version');
 
     const exact2h = buttons.find(b =>
       b.callback_data.startsWith('approve:') && b.callback_data.endsWith(':exact:2'),
@@ -125,38 +133,29 @@ describe('Telegram E2E: approval flow', () => {
 
     await pressInlineButton(ctx, exact2h!.callback_data, exact2h!.messageId);
 
-    await waitForStatus(requestId, 'completed');
-
-    const statusRes = await request(ctx.app)
-      .get(`/api/v1/status/${requestId}`)
-      .set('x-api-key', ctx.testKey);
-
-    expect(statusRes.status).toBe(200);
-    expect(statusRes.body.status).toBe('completed');
-    expect(statusRes.body.exitCode).toBe(0);
-    expect(statusRes.body.stdout).toContain('git version');
+    const res = await execPromise;
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('completed');
+    expect(res.body.exitCode).toBe(0);
+    expect(res.body.stdout).toContain('git version');
   }, 20_000);
 
   it('denies command via deny button', async () => {
-    const { requestId, buttons } = await submitAndGetButtons('git log --oneline -5');
+    const { execPromise, buttons } = await fireAndGetButtons('git log --oneline -5');
 
     const denyBtn = buttons.find(b => b.callback_data.startsWith('deny:'));
     expect(denyBtn).toBeDefined();
 
     await pressInlineButton(ctx, denyBtn!.callback_data, denyBtn!.messageId);
 
-    await waitForStatus(requestId, 'denied');
-
-    const statusRes = await request(ctx.app)
-      .get(`/api/v1/status/${requestId}`)
-      .set('x-api-key', ctx.testKey);
-
-    expect(statusRes.status).toBe(200);
-    expect(statusRes.body.status).toBe('denied');
+    const res = await execPromise;
+    expect(res.status).toBe(403);
+    expect(res.body.status).toBe('denied');
+    expect(res.body.code).toBe('DENIED');
   }, 20_000);
 
   it('approves via prefix button and reuses approval for similar command', async () => {
-    const { requestId: requestId1, buttons } = await submitAndGetButtons('ls -la /tmp');
+    const { execPromise, buttons } = await fireAndGetButtons('ls -la /tmp');
 
     const prefix8h = buttons.find(b =>
       b.callback_data.startsWith('approve:') && b.callback_data.endsWith(':prefix:8'),
@@ -165,21 +164,20 @@ describe('Telegram E2E: approval flow', () => {
 
     await pressInlineButton(ctx, prefix8h!.callback_data, prefix8h!.messageId);
 
-    await waitForStatus(requestId1, 'completed');
+    const first = await execPromise;
+    expect(first.status).toBe(200);
+    expect(first.body.status).toBe('completed');
 
     // Second command with same prefix "ls -la" should be auto-approved (cached)
-    const execRes2 = await request(ctx.app)
-      .post('/api/v1/execute?sync=true')
-      .set('x-api-key', ctx.testKey)
-      .send({ command: 'ls -la /var' });
+    const res2 = await fireExecute(ctx, 'ls -la /var');
 
-    expect(execRes2.status).toBe(200);
-    expect(execRes2.body.status).toBe('completed');
-    expect(execRes2.body.exitCode).toBe(0);
+    expect(res2.status).toBe(200);
+    expect(res2.body.status).toBe('completed');
+    expect(res2.body.exitCode).toBe(0);
   }, 25_000);
 
   it('approves via exact-permanent button', async () => {
-    const { requestId, buttons } = await submitAndGetButtons('git branch');
+    const { execPromise, buttons } = await fireAndGetButtons('git branch');
 
     const exactPerm = buttons.find(b =>
       b.callback_data.startsWith('approve:') && b.callback_data.endsWith(':exact:permanent'),
@@ -188,50 +186,47 @@ describe('Telegram E2E: approval flow', () => {
 
     await pressInlineButton(ctx, exactPerm!.callback_data, exactPerm!.messageId);
 
-    await waitForStatus(requestId, 'completed');
+    const first = await execPromise;
+    expect(first.status).toBe(200);
+    expect(first.body.status).toBe('completed');
 
     // Same command should now be auto-approved (permanent exact cache)
-    const execRes2 = await request(ctx.app)
-      .post('/api/v1/execute?sync=true')
-      .set('x-api-key', ctx.testKey)
-      .send({ command: 'git branch' });
+    const res2 = await fireExecute(ctx, 'git branch');
 
-    expect(execRes2.status).toBe(200);
-    expect(execRes2.body.status).toBe('completed');
+    expect(res2.status).toBe(200);
+    expect(res2.body.status).toBe('completed');
   }, 25_000);
 
   it('shows risk warnings in the Telegram message for dangerous commands', async () => {
-    const { buttons, lastMsg } = await submitAndGetButtons('git push --force origin main');
+    const { execPromise, buttons, lastMsg } = await fireAndGetButtons('git push --force origin main');
 
     // The message should contain the command text
     expect(lastMsg.message.text).toContain('git push --force origin main');
 
-    // Clean up: deny it so it doesn't linger
-    const denyBtn = buttons.find(b => b.callback_data.startsWith('deny:'));
-    if (denyBtn) {
-      await pressInlineButton(ctx, denyBtn.callback_data, denyBtn.messageId);
-    }
+    // Clean up: deny it so the POST resolves
+    const denyBtn = buttons.find(b => b.callback_data.startsWith('deny:'))!;
+    await pressInlineButton(ctx, denyBtn.callback_data, denyBtn.messageId);
+    const res = await execPromise;
+    expect(res.status).toBe(403);
   }, 15_000);
 
-  it('sync mode returns result when pre-existing approval covers the command', async () => {
-    // First, approve "git tag" via the async flow (which works reliably)
-    const { requestId, buttons } = await submitAndGetButtons('git tag');
+  it('returns result without hitting Telegram when a pre-existing approval covers the command', async () => {
+    // First, approve "git tag" via a live Telegram exchange so the approval is cached.
+    const { execPromise, buttons } = await fireAndGetButtons('git tag');
     const exact8h = buttons.find(b =>
       b.callback_data.startsWith('approve:') && b.callback_data.endsWith(':exact:8'),
     );
     expect(exact8h).toBeDefined();
     await pressInlineButton(ctx, exact8h!.callback_data, exact8h!.messageId);
-    await waitForStatus(requestId, 'completed');
+    const first = await execPromise;
+    expect(first.status).toBe(200);
 
-    // Now use sync mode — the cached approval should make it return immediately
-    const syncRes = await request(ctx.app)
-      .post('/api/v1/execute?sync=true')
-      .set('x-api-key', ctx.testKey)
-      .send({ command: 'git tag' });
+    // Subsequent call reuses the cached approval — no Telegram prompt required.
+    const res = await fireExecute(ctx, 'git tag');
 
-    expect(syncRes.status).toBe(200);
-    expect(syncRes.body.status).toBe('completed');
-    expect(syncRes.body.exitCode).toBe(0);
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('completed');
+    expect(res.body.exitCode).toBe(0);
   }, 25_000);
 });
 
@@ -346,14 +341,16 @@ describe('Telegram E2E: first onboarding journey', () => {
   }, 15_000);
 
   it('init → start with Telegram → submit command → approve via button → command completes', async () => {
-    // Submit a command that needs Telegram approval, using the --init generated key
-    const execRes = await request(appResult.app)
-      .post('/api/v1/execute')
-      .set('x-api-key', apiKey)
-      .send({ command: 'echo tg-onboard hello' });
-
-    expect(execRes.status).toBe(202);
-    const { requestId } = execRes.body;
+    // Fire the POST immediately (via `.end(cb)`) so it dispatches before we
+    // start waiting for the bot message. The sync handler blocks until
+    // Telegram decides.
+    const execPromise = new Promise<Response>((resolveE, rejectE) => {
+      request(appResult.app)
+        .post('/api/v1/execute')
+        .set('x-api-key', apiKey)
+        .send({ command: 'echo tg-onboard hello' })
+        .end((err, res) => err ? rejectE(err) : resolveE(res));
+    });
 
     // Wait for bot to send the approval request to Telegram
     const onboardCtx = { telegramServer, telegramClient, testKey: apiKey, app: appResult.app, start: appResult.start, stop: appResult.stop, testDir: tmpDir };
@@ -391,30 +388,19 @@ describe('Telegram E2E: first onboarding journey', () => {
     });
     await telegramClient.sendCallback(cbQuery);
 
-    // Wait for the command to complete
-    await waitForCondition(async () => {
-      const statusRes = await request(appResult.app)
-        .get(`/api/v1/status/${requestId}`)
-        .set('x-api-key', apiKey);
-      return statusRes.status === 200 && statusRes.body.status === 'completed';
-    }, 10_000);
+    // The POST should now resolve with the execution result.
+    const res = await execPromise;
 
-    // Verify final status
-    const statusRes = await request(appResult.app)
-      .get(`/api/v1/status/${requestId}`)
-      .set('x-api-key', apiKey);
-
-    expect(statusRes.status).toBe(200);
-    expect(statusRes.body.status).toBe('completed');
-    expect(statusRes.body.exitCode).toBe(0);
-    expect(statusRes.body.stdout).toContain('tg-onboard hello');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('completed');
+    expect(res.body.exitCode).toBe(0);
+    expect(res.body.stdout).toContain('tg-onboard hello');
   }, 25_000);
 });
 
 // ─── Journey: Deny and Approve-Once via Telegram ─────────────────────────
 // Verifies deny rejects the command, and approve-once executes the command
-// without caching the approval. Also validates that the request correctly
-// waits for the Telegram decision (regression test for issue #4).
+// without caching the approval.
 
 describe('Telegram E2E: deny and approve-once journey', () => {
   let journeyCtx: TelegramE2EContext;
@@ -432,108 +418,56 @@ describe('Telegram E2E: deny and approve-once journey', () => {
   it('deny → command is rejected, approve-once → command completes without cached approval', async () => {
     // ── Part 1: Deny ─────────────────────────────────────────────
 
-    // Submit a command that needs approval
-    const denyExecRes = await request(journeyCtx.app)
-      .post('/api/v1/execute')
-      .set('x-api-key', journeyCtx.testKey)
-      .send({ command: 'git diff --stat' });
+    const denyPromise = fireExecute(journeyCtx, 'git diff --stat');
 
-    expect(denyExecRes.status).toBe(202);
-    const denyRequestId = denyExecRes.body.requestId;
-
-    // Wait for the Telegram message
     await waitForBotMessage(journeyCtx);
     const denyUpdates = await getBotMessages(journeyCtx) as any as BotMessageResult;
     const denyButtons = extractInlineButtons(denyUpdates);
 
-    // Press the deny button
     const denyBtn = denyButtons.find(b => b.callback_data.startsWith('deny:'));
     expect(denyBtn).toBeDefined();
     await pressInlineButton(journeyCtx, denyBtn!.callback_data, denyBtn!.messageId);
 
-    // Wait for the request to be denied
-    await waitForStatus(denyRequestId, 'denied');
-
-    const denyStatusRes = await request(journeyCtx.app)
-      .get(`/api/v1/status/${denyRequestId}`)
-      .set('x-api-key', journeyCtx.testKey);
-    expect(denyStatusRes.status).toBe(200);
-    expect(denyStatusRes.body.status).toBe('denied');
+    const denyRes = await denyPromise;
+    expect(denyRes.status).toBe(403);
+    expect(denyRes.body.status).toBe('denied');
 
     // ── Part 2: Approve Once ─────────────────────────────────────
 
-    // Submit a command that needs approval
-    const onceExecRes = await request(journeyCtx.app)
-      .post('/api/v1/execute')
-      .set('x-api-key', journeyCtx.testKey)
-      .send({ command: 'git diff --stat' });
+    const oncePromise = fireExecute(journeyCtx, 'git diff --stat');
 
-    expect(onceExecRes.status).toBe(202);
-    const onceRequestId = onceExecRes.body.requestId;
-
-    // Wait for the Telegram message
     await waitForBotMessage(journeyCtx);
     const onceUpdates = await getBotMessages(journeyCtx) as any as BotMessageResult;
     const onceButtons = extractInlineButtons(onceUpdates);
 
-    // Press the "Once" button
     const onceBtn = onceButtons.find(b =>
       b.callback_data.startsWith('approve:') && b.callback_data.includes(':once:'),
     );
     expect(onceBtn).toBeDefined();
     await pressInlineButton(journeyCtx, onceBtn!.callback_data, onceBtn!.messageId);
 
-    // Wait for the command to complete (validates issue #4 — request waits for approval)
-    await waitForStatus(onceRequestId, 'completed');
-
-    const onceStatusRes = await request(journeyCtx.app)
-      .get(`/api/v1/status/${onceRequestId}`)
-      .set('x-api-key', journeyCtx.testKey);
-    expect(onceStatusRes.status).toBe(200);
-    expect(onceStatusRes.body.status).toBe('completed');
-    expect(onceStatusRes.body.exitCode).toBe(0);
+    const onceRes = await oncePromise;
+    expect(onceRes.status).toBe(200);
+    expect(onceRes.body.status).toBe('completed');
+    expect(onceRes.body.exitCode).toBe(0);
 
     // ── Part 3: Verify no cached approval ────────────────────────
+    // The same command should still require approval — once-approve doesn't
+    // persist to the approval cache. Fire the POST and watch a new prompt
+    // arrive; then clean up by denying so the promise settles.
+    const repeatPromise = fireExecute(journeyCtx, 'git diff --stat');
 
-    // Submit the same command again — it should require approval again
-    // (not auto-approved from cache, since we used "once")
-    const repeatExecRes = await request(journeyCtx.app)
-      .post('/api/v1/execute')
-      .set('x-api-key', journeyCtx.testKey)
-      .send({ command: 'git diff --stat' });
-
-    expect(repeatExecRes.status).toBe(202);
-    expect(repeatExecRes.body.status).toBe('pending_approval');
-
-    // The request should NOT be auto-approved — it should still be pending
-    // Wait a moment and verify it didn't complete on its own
-    await new Promise(r => setTimeout(r, 500));
-    const repeatStatusRes = await request(journeyCtx.app)
-      .get(`/api/v1/status/${repeatExecRes.body.requestId}`)
-      .set('x-api-key', journeyCtx.testKey);
-    // It should be either pending or in the pending store, not completed
-    if (repeatStatusRes.status === 200) {
-      expect(repeatStatusRes.body.status).toBe('pending_approval');
-    }
-
-    // Clean up: deny the last pending request
     await waitForBotMessage(journeyCtx);
     const cleanupUpdates = await getBotMessages(journeyCtx) as any as BotMessageResult;
     const cleanupButtons = extractInlineButtons(cleanupUpdates);
     const cleanupDeny = cleanupButtons.find(b => b.callback_data.startsWith('deny:'));
-    if (cleanupDeny) {
-      await pressInlineButton(journeyCtx, cleanupDeny.callback_data, cleanupDeny.messageId);
-    }
+    expect(cleanupDeny).toBeDefined();
+    await pressInlineButton(journeyCtx, cleanupDeny!.callback_data, cleanupDeny!.messageId);
+
+    const repeatRes = await repeatPromise;
+    expect(repeatRes.status).toBe(403);
+    expect(repeatRes.body.status).toBe('denied');
   }, 40_000);
   /* eslint-enable @typescript-eslint/no-explicit-any */
-
-  /** Helper: wait for request to reach terminal status within this describe block. */
-  async function waitForStatus(requestId: string, expectedStatus: string, timeoutMs = 10_000) {
-    await waitForCondition(async () => {
-      const statusRes = await request(journeyCtx.app)
-        .get(`/api/v1/status/${requestId}`)
-        .set('x-api-key', journeyCtx.testKey);
-      return statusRes.status === 200 && statusRes.body.status === expectedStatus;
-    }, timeoutMs);
-  }
 });
+


### PR DESCRIPTION
## Summary

- **BREAKING: POST `/api/v1/execute` is now always synchronous.** The handler blocks until the command reaches a terminal state (completed, failed, denied, or timed_out) and returns the full result in a single response. The `?sync=true` query param and `GET /api/v1/status/:requestId` polling endpoint are removed.
- **409 DUPLICATE_IN_FLIGHT** is returned when an identical command from the same API key is already awaiting approval. The error is marked retryable.
- **Internal simplifications:** `processApprovalAsync`, `completedResults` cache, its cleanup interval, and the async 202 `pending_approval` response path are all removed. Client-disconnect abort switches from `req.on('close')` to `res.on('close')` gated on `res.writableEnded` to prevent spurious aborts on normal response end in newer Node.
- Docs (README, DOMAIN-BOUNDARIES, USER-JOURNEYS, command-execution spec) updated to describe the new synchronous contract and the 409 error code.

Prior commit on this branch: `f505031` fix(cli): clean exit for one-shot commands, friendly pair, add `start` (already on master).

## Test plan

- [ ] All existing unit tests pass (`npm run test`)
- [ ] Lint clean (`npm run lint`)
- [ ] Build succeeds (`npm run build`)
- [ ] SonarCloud reports zero new issues
- [ ] GitHub Actions checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)