### PR TITLE
feat(#16): transparent HTTP proxy with configurable port, upstream, and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,44 @@ e.g. put `{ "prefix": "deploy", "action": "manual_approve" }` in
 `command-rules.json`). Exact-string match only — an alias `deploy` does not
 match `deploy --dry-run`; that falls through to the shell path.
 
+### Transparent HTTP proxy (optional)
+
+Lucifer can also run one or more transparent HTTP proxy listeners alongside
+the main gateway. Each listener forwards every request it receives to a
+configured upstream, preserving path, method, query string and body, and
+injecting a fixed set of outgoing headers.
+
+Drop `config/proxy-config.json`:
+
+```json
+{
+  "proxies": [
+    {
+      "port": 6060,
+      "baseUrl": "https://api.openai.com",
+      "headers": { "Authorization": "Bearer sk-..." }
+    }
+  ]
+}
+```
+
+A request to `http://localhost:6060/v1/chat/completions` is forwarded to
+`https://api.openai.com/v1/chat/completions` with the configured
+`Authorization` header attached server-side. Configured headers **overwrite**
+any caller-supplied header of the same name, so callers never need (and
+cannot spoof) the upstream credential.
+
+File semantics:
+
+- File missing → feature disabled (no behavior change for existing installs).
+- File present with `proxies: []` → feature enabled, no listeners started.
+- Ports must be in 1–65535 and must not collide with the gateway port or
+  with each other — validated at startup.
+- `baseUrl` must be a syntactically valid `http://` or `https://` URL.
+
+See [docs/specs/transparent-proxy.md](docs/specs/transparent-proxy.md) for
+the full contract.
+
 ## Production setup (with Telegram)
 
 1. Create a Telegram bot via [@BotFather](https://t.me/BotFather) and get the token
@@ -236,6 +274,10 @@ server/src/domains/
     service/             Auth, rules, risk analysis, execution, approvals
     api/                 Execute routes + web approval UI routes
   platform-api/          Health endpoint + server runtime wiring
+  request-proxy/         Optional transparent HTTP proxy listeners
+    types/               ProxyMapping, ProxyConfig
+    config/              proxy-config.json loader + port-collision validation
+    service/             http-proxy-middleware-backed listeners
 ```
 
 Dependency flow: Types -> Config -> Repository -> Service -> Runtime -> UI/API

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ File semantics:
 - Ports must be in 1–65535 and must not collide with the gateway port or
   with each other — validated at startup.
 - `baseUrl` must be a syntactically valid `http://` or `https://` URL.
+- Listeners bind to `127.0.0.1` by default. Set `"host": "0.0.0.0"` on a
+  mapping to expose it beyond loopback; when doing so, the operator is
+  responsible for fronting the listener with access control.
 
 See [docs/specs/transparent-proxy.md](docs/specs/transparent-proxy.md) for
 the full contract.

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -21,6 +21,7 @@ an external caller and the local shell.
 |---|---|---|---|
 | `command-gateway` | Core domain: request auth, policy rules, approval channels, command execution, audit | Active | See QUALITY |
 | `platform-api` | Server bootstrap plus platform-facing HTTP surface such as `/api/health` | Active | See QUALITY |
+| `request-proxy` | Optional HTTP proxy listeners that forward to configured upstreams with header injection | Active | See QUALITY |
 
 ## Layer Structure (per domain)
 

--- a/docs/context/DECISIONS.md
+++ b/docs/context/DECISIONS.md
@@ -293,3 +293,79 @@ Add an optional `aliases` map to `lucifer.json` of the shape `{ [name]: { path, 
 - **Dedicated alias endpoint (`POST /api/v1/alias/:name`)**. Rejected: splits audit, approval, and rule flows across two endpoints. Keeping one `/execute` endpoint means alias and non-alias commands share identical machinery.
 - **More alias types (`python`, `node`, custom interpreter templates)**. Deferred. Two types cover the v1 need; adding more is additive.
 - **First-token match with argument passthrough** (`"deploy --dry-run"` → alias `deploy` with argv `["--dry-run"]`). Deferred: requires a separate decision on how to tokenize the remainder of the command string (naive whitespace vs shell-style vs an API change), and changes the behavior of inputs that currently fall through to the shell.
+
+---
+
+## ADR-010: Transparent HTTP proxy as a separate domain on its own ports
+
+**Date**: 2026-04-17
+**Status**: Accepted
+**Deciders**: alkampfergit
+
+### Context
+
+Lucifer is primarily a command firewall, but operators also want it to act as
+a transparent HTTP proxy in front of upstream AI APIs (e.g. OpenAI). The
+proxy must inject authentication headers server-side so callers don't hold
+the credential, while preserving path, method, body, and query string.
+
+Three design axes needed decisions:
+
+1. **Where does the proxy live?** Inside `command-gateway`, inside
+   `platform-api`, or in its own domain.
+2. **Where does the config live?** Embedded in `lucifer.json` (like
+   `aliases`) or in a separate file.
+3. **Does the feature share the main gateway port?** Sub-path on the
+   existing listener, or dedicated listeners on operator-chosen ports.
+
+### Decision
+
+- **New domain `request-proxy`** with `types/`, `config/`, and `service/`
+  layers. No `api/` layer: the proxy exposes no surface on the main Express
+  app.
+- **Dedicated config file `proxy-config.json`** alongside `lucifer.json`.
+  File absent → feature disabled. File present with `{ "proxies": [] }` →
+  feature enabled, no listeners.
+- **One dedicated HTTP listener per mapping**, on an operator-chosen port.
+  Ports must not collide with each other or with the main gateway port;
+  validated at startup.
+- **Library**: `http-proxy-middleware` (well-maintained, Express-compatible,
+  wraps `http-proxy`). No bespoke proxy logic.
+- **Header semantics**: configured headers *overwrite* caller-supplied
+  headers of the same name. The primary use is credential injection where
+  the caller must not be able to override the configured value.
+
+### Consequences
+
+- (+) Clear separation: command-gateway stays focused on command firewalling.
+- (+) Secrets (proxy auth headers) live in their own file operators can
+  mount as a secret / restrict via file permissions independently of
+  `lucifer.json`.
+- (+) Opt-in: legacy installs that never create `proxy-config.json` see no
+  behavior change.
+- (+) Dedicated listeners mean proxy traffic bypasses the gateway's API-key
+  middleware and rate limiter — appropriate because the proxy has its own
+  auth model (the injected credential on the outbound side).
+- (-) Two config files to manage instead of one.
+- (-) Operators must pick and manage additional ports.
+- (-) No policy enforcement on proxied traffic beyond header injection
+  (explicitly out of scope for v1).
+
+### Alternatives Considered
+
+- **Embed proxy mappings in `lucifer.json`**. Rejected: auth headers are
+  secrets, and bundling them into the main config works against operators
+  who want to rotate credentials or mount them from a secret manager
+  independently.
+- **Sub-path on the main gateway port** (e.g. `/proxy/openai/*`). Rejected:
+  it forces the caller to know the proxy exists and rewrites path prefixes
+  — no longer "transparent". Also couples proxy lifecycle to the gateway
+  port and to its API-key middleware.
+- **Put the proxy inside `command-gateway`**. Rejected: HTTP proxying has
+  no relation to command approval or execution; mixing them would make
+  `command-gateway`'s responsibilities harder to reason about.
+- **Hand-rolled proxy using Node streams**. Rejected per the issue brief —
+  use a well-maintained library.
+- **Let configured headers *merge* with caller-supplied headers rather than
+  overwrite**. Rejected: caller-supplied `Authorization` overriding the
+  configured credential would defeat the feature's primary purpose.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -14,6 +14,7 @@ implementation in detail. Specs should stay short, factual, and tied to code.
 | [approval-channels.md](approval-channels.md) | Telegram, web admin, auto-approve, and cached approvals |
 | [operator-workflows.md](operator-workflows.md) | Init, pairing, logging, stats, and runtime config |
 | [platform-health.md](platform-health.md) | Health endpoint and runtime status contract |
+| [transparent-proxy.md](transparent-proxy.md) | Optional HTTP proxy listeners with header injection |
 
 ## Rules
 

--- a/docs/specs/transparent-proxy.md
+++ b/docs/specs/transparent-proxy.md
@@ -37,6 +37,11 @@ Field rules:
   request. **Overwrites** any caller-supplied header of the same name (the
   primary use is credential injection, which must not be overridable by the
   caller).
+- `host` — optional bind address. Defaults to `127.0.0.1` (loopback only)
+  so a credentialed proxy is not accidentally exposed to the local
+  network. Set explicitly (e.g. `"0.0.0.0"`) to opt into broader binding;
+  the operator accepts responsibility for fronting the listener with its
+  own access control when doing so.
 
 File semantics:
 
@@ -64,6 +69,18 @@ Proxy listeners are created when the main server starts and closed when
 the server stops. They are independent of command-gateway lifecycle — the
 feature can be enabled even if no command-gateway config files are
 present.
+
+Startup is all-or-nothing:
+
+- If any listener fails to bind, all already-started listeners are closed
+  before the startup error is rethrown. The caller never observes a
+  half-started set.
+- Likewise, if the proxy layer fails to come up after the approval
+  channel, `createApp().start()` rolls back the approval channel before
+  rethrowing.
+
+Shutdown is best-effort: a listener that never bound (e.g. because
+startup failed partway) does not prevent cleanup of the others.
 
 ## What it does NOT do (yet)
 

--- a/docs/specs/transparent-proxy.md
+++ b/docs/specs/transparent-proxy.md
@@ -1,0 +1,74 @@
+# Transparent Proxy
+
+## What it does
+
+Runs one or more HTTP listeners alongside the main gateway. Each listener
+forwards every incoming request to a configured base URL, preserving path,
+method, query string, and body, and injecting a configured set of headers
+on the outgoing request.
+
+Primary use case: put an AI-agent upstream (e.g. the OpenAI API) behind a
+local port so callers never need to know the upstream URL or hold the
+credential directly.
+
+## Config file
+
+`proxy-config.json` (same directory as `lucifer.json`):
+
+```json
+{
+  "proxies": [
+    {
+      "port": 6060,
+      "baseUrl": "https://api.openai.com",
+      "headers": { "Authorization": "Bearer sk-..." }
+    }
+  ]
+}
+```
+
+Field rules:
+
+- `port` — integer, 1–65535. Must not collide with the main gateway port
+  or with any other proxy port. Collisions fail fast at startup.
+- `baseUrl` — absolute URL with `http:` or `https:` scheme. Validated with
+  `new URL()` at load time.
+- `headers` — optional map of string → string. Injected on every outgoing
+  request. **Overwrites** any caller-supplied header of the same name (the
+  primary use is credential injection, which must not be overridable by the
+  caller).
+
+File semantics:
+
+- File missing → proxy feature disabled (legacy deployments unchanged).
+- File present with `proxies: []` → loaded, no listeners started.
+- File present with any invalid entry → server fails to start.
+
+## Request forwarding
+
+- Path and query string are forwarded unchanged:
+  `http://localhost:6060/v1/chat/completions?x=1` →
+  `https://api.openai.com/v1/chat/completions?x=1`.
+- The upstream `Host` header is rewritten to the target's host
+  (`changeOrigin: true`), which is required by most TLS-terminating
+  upstreams.
+- Streaming responses pass through (the underlying `http-proxy` library
+  supports streaming by default), so SSE-style endpoints like
+  `/v1/chat/completions` with `stream: true` work as expected.
+- Upstream connection errors surface as HTTP `502` with body
+  `{ "error": "bad_gateway", "message": "Upstream request failed" }`.
+
+## Lifecycle
+
+Proxy listeners are created when the main server starts and closed when
+the server stops. They are independent of command-gateway lifecycle — the
+feature can be enabled even if no command-gateway config files are
+present.
+
+## What it does NOT do (yet)
+
+- Per-path routing within a single mapping.
+- Rate limiting on proxy ports.
+- TLS termination on proxy listeners (run TLS in an upstream reverse
+  proxy).
+- Rewriting response bodies or streaming policy enforcement.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "better-sqlite3": "^12.8.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.2",
+        "http-proxy-middleware": "^3.0.5",
         "pino": "^10.3.1",
         "telegraf": "^4.16.3"
       },
@@ -1165,6 +1166,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1183,7 +1193,6 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1889,6 +1898,18 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/buffer": {
@@ -2599,6 +2620,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2751,6 +2778,18 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2814,7 +2853,6 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3108,6 +3146,37 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/http-shutdown": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz",
@@ -3226,7 +3295,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3236,11 +3304,28 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3658,6 +3743,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -4332,6 +4442,12 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -5345,6 +5461,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -5476,7 +5604,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "better-sqlite3": "^12.8.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.2",
+    "http-proxy-middleware": "^3.0.5",
     "pino": "^10.3.1",
     "telegraf": "^4.16.3"
   },

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -52,6 +52,7 @@ function initConfig(targetDir: string) {
   const luciferJsonPath = join(configDir, 'lucifer.json');
   const apiKeysPath = join(configDir, 'api-keys.json');
   const commandRulesPath = join(configDir, 'command-rules.json');
+  const proxyConfigPath = join(configDir, 'proxy-config.json');
 
   if (existsSync(luciferJsonPath)) {
     console.log(`Config already exists: ${luciferJsonPath}`);
@@ -101,10 +102,15 @@ function initConfig(targetDir: string) {
     defaultAction: 'always_deny',
   }, null, 2) + '\n');
 
+  writeFileSync(proxyConfigPath, JSON.stringify({
+    proxies: [],
+  }, null, 2) + '\n');
+
   console.log('Config files generated:');
   console.log(`  ${luciferJsonPath}`);
   console.log(`  ${apiKeysPath}`);
   console.log(`  ${commandRulesPath}`);
+  console.log(`  ${proxyConfigPath}`);
   console.log('');
   console.log('Your API key (save this, it cannot be recovered):');
   console.log(`  ${key}`);

--- a/server/src/create_app.ts
+++ b/server/src/create_app.ts
@@ -150,18 +150,41 @@ export function createApp(options: CreateAppOptions = {}) {
   }
 
   async function start() {
-    if (approvalChannel) {
-      await approvalChannel.start()
-    }
-    if (proxyServers) {
-      await proxyServers.start()
+    // All-or-nothing: if any later step fails, roll back earlier ones so
+    // callers never observe a half-started app (e.g. Telegram bot polling
+    // while the proxy port failed to bind).
+    const started: Array<() => Promise<void>> = []
+    try {
+      if (approvalChannel) {
+        await approvalChannel.start()
+        started.push(() => approvalChannel!.stop())
+      }
+      if (proxyServers) {
+        await proxyServers.start()
+        started.push(() => proxyServers!.stop())
+      }
+    } catch (err) {
+      for (const rollback of started.reverse()) {
+        try { await rollback() } catch (rollbackErr) {
+          log.warn({ err: rollbackErr }, 'Error rolling back partial startup')
+        }
+      }
+      throw err
     }
   }
 
   async function stop() {
     if (cleanupInterval) clearInterval(cleanupInterval)
-    if (approvalChannel) await approvalChannel.stop()
-    if (proxyServers) await proxyServers.stop()
+    if (approvalChannel) {
+      try { await approvalChannel.stop() } catch (err) {
+        log.warn({ err }, 'Error stopping approval channel')
+      }
+    }
+    if (proxyServers) {
+      try { await proxyServers.stop() } catch (err) {
+        log.warn({ err }, 'Error stopping proxy servers')
+      }
+    }
     closeDatabase()
   }
 

--- a/server/src/create_app.ts
+++ b/server/src/create_app.ts
@@ -19,6 +19,8 @@ import { createWebApprovalChannel } from './domains/command-gateway/service/web_
 import { createMultiApprovalChannel } from './domains/command-gateway/service/multi_approval_channel.js'
 import { registerApprovalRoutes } from './domains/command-gateway/api/register_approval_routes.js'
 import type { ApprovalChannel } from './domains/command-gateway/types/command_types.js'
+import { loadProxyConfig, validateProxyPorts } from './domains/request-proxy/config/proxy_config.js'
+import { createProxyServers, type ProxyServers } from './domains/request-proxy/service/proxy_server.js'
 import { createChildLogger, addLogFile } from './lib/logger.js'
 
 const log = createChildLogger('app')
@@ -86,6 +88,7 @@ export function createApp(options: CreateAppOptions = {}) {
   const configDir = options.configPath ? path.dirname(path.resolve(options.configPath)) : process.cwd()
   const apiKeysPath = path.join(configDir, 'api-keys.json')
   const commandRulesPath = path.join(configDir, 'command-rules.json')
+  const proxyConfigPath = path.join(configDir, 'proxy-config.json')
 
   // Resolve dataDir relative to config directory
   const resolvedDataDir = path.resolve(configDir, gatewayConfig.dataDir)
@@ -137,15 +140,28 @@ export function createApp(options: CreateAppOptions = {}) {
     log.warn('Ensure HTTPS is configured for production. API keys are transmitted in headers.')
   }
 
+  // Transparent proxy listeners (optional, separate from the gateway port)
+  let proxyServers: ProxyServers | undefined
+  const proxyConfig = loadProxyConfig(proxyConfigPath)
+  if (proxyConfig && proxyConfig.proxies.length > 0) {
+    validateProxyPorts(proxyConfig.proxies, gatewayConfig.port)
+    proxyServers = createProxyServers(proxyConfig.proxies)
+    log.info({ count: proxyConfig.proxies.length }, 'Transparent proxy mappings configured')
+  }
+
   async function start() {
     if (approvalChannel) {
       await approvalChannel.start()
+    }
+    if (proxyServers) {
+      await proxyServers.start()
     }
   }
 
   async function stop() {
     if (cleanupInterval) clearInterval(cleanupInterval)
     if (approvalChannel) await approvalChannel.stop()
+    if (proxyServers) await proxyServers.stop()
     closeDatabase()
   }
 

--- a/server/src/domains/request-proxy/config/proxy_config.test.ts
+++ b/server/src/domains/request-proxy/config/proxy_config.test.ts
@@ -86,7 +86,7 @@ describe('loadProxyConfig', () => {
   it('rejects a non-http baseUrl', () => {
     const dir = createTempDir();
     const filePath = writeProxyFile(dir, {
-      proxies: [{ port: 6060, baseUrl: 'ftp://api.openai.com' }],
+      proxies: [{ port: 6060, baseUrl: 'file:///tmp/not-a-proxy' }],
     });
     expect(() => loadProxyConfig(filePath)).toThrow('failed validation');
   });

--- a/server/src/domains/request-proxy/config/proxy_config.test.ts
+++ b/server/src/domains/request-proxy/config/proxy_config.test.ts
@@ -67,6 +67,40 @@ describe('loadProxyConfig', () => {
     expect(config?.proxies[0].headers).toBeUndefined();
   });
 
+  it('loads an explicit host override', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 7070, baseUrl: 'http://localhost:9000', host: '0.0.0.0' }],
+    });
+    const config = loadProxyConfig(filePath);
+    expect(config?.proxies[0].host).toBe('0.0.0.0');
+  });
+
+  it('leaves host undefined when omitted (caller applies loopback default)', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 7070, baseUrl: 'http://localhost:9000' }],
+    });
+    const config = loadProxyConfig(filePath);
+    expect(config?.proxies[0].host).toBeUndefined();
+  });
+
+  it('rejects a non-string host', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 7070, baseUrl: 'http://localhost:9000', host: 123 }],
+    });
+    expect(() => loadProxyConfig(filePath)).toThrow('failed validation');
+  });
+
+  it('rejects an empty host string', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 7070, baseUrl: 'http://localhost:9000', host: '' }],
+    });
+    expect(() => loadProxyConfig(filePath)).toThrow('failed validation');
+  });
+
   it('rejects a non-integer port', () => {
     const dir = createTempDir();
     const filePath = writeProxyFile(dir, {

--- a/server/src/domains/request-proxy/config/proxy_config.test.ts
+++ b/server/src/domains/request-proxy/config/proxy_config.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadProxyConfig, validateProxyPorts } from './proxy_config.js';
+
+const tempDirs: string[] = [];
+
+function createTempDir(): string {
+  const dir = join(tmpdir(), `lucifer-proxy-config-test-${Date.now()}-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeProxyFile(dir: string, body: unknown): string {
+  const filePath = join(dir, 'proxy-config.json');
+  writeFileSync(filePath, JSON.stringify(body));
+  return filePath;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+describe('loadProxyConfig', () => {
+  it('returns undefined when configPath is undefined', () => {
+    expect(loadProxyConfig(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when the file does not exist', () => {
+    const dir = createTempDir();
+    expect(loadProxyConfig(join(dir, 'proxy-config.json'))).toBeUndefined();
+  });
+
+  it('loads an empty proxies array', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, { proxies: [] });
+    const config = loadProxyConfig(filePath);
+    expect(config).toEqual({ proxies: [] });
+  });
+
+  it('loads a single mapping with headers', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [
+        { port: 6060, baseUrl: 'https://api.openai.com', headers: { Authorization: 'Bearer x' } },
+      ],
+    });
+    const config = loadProxyConfig(filePath);
+    expect(config?.proxies).toHaveLength(1);
+    expect(config?.proxies[0].port).toBe(6060);
+    expect(config?.proxies[0].baseUrl).toBe('https://api.openai.com');
+    expect(config?.proxies[0].headers).toEqual({ Authorization: 'Bearer x' });
+  });
+
+  it('loads a mapping without headers', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 7070, baseUrl: 'http://localhost:9000' }],
+    });
+    const config = loadProxyConfig(filePath);
+    expect(config?.proxies[0].headers).toBeUndefined();
+  });
+
+  it('rejects a non-integer port', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 80.5, baseUrl: 'https://api.openai.com' }],
+    });
+    expect(() => loadProxyConfig(filePath)).toThrow('failed validation');
+  });
+
+  it('rejects an out-of-range port', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 70000, baseUrl: 'https://api.openai.com' }],
+    });
+    expect(() => loadProxyConfig(filePath)).toThrow('failed validation');
+  });
+
+  it('rejects a non-http baseUrl', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 6060, baseUrl: 'ftp://api.openai.com' }],
+    });
+    expect(() => loadProxyConfig(filePath)).toThrow('failed validation');
+  });
+
+  it('rejects a malformed baseUrl', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 6060, baseUrl: 'not a url' }],
+    });
+    expect(() => loadProxyConfig(filePath)).toThrow('failed validation');
+  });
+
+  it('rejects non-string header values', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {
+      proxies: [{ port: 6060, baseUrl: 'https://api.openai.com', headers: { X: 1 } }],
+    });
+    expect(() => loadProxyConfig(filePath)).toThrow('failed validation');
+  });
+
+  it('rejects a missing proxies array', () => {
+    const dir = createTempDir();
+    const filePath = writeProxyFile(dir, {});
+    expect(() => loadProxyConfig(filePath)).toThrow('failed validation');
+  });
+});
+
+describe('validateProxyPorts', () => {
+  it('accepts disjoint ports', () => {
+    expect(() =>
+      validateProxyPorts(
+        [
+          { port: 6060, baseUrl: 'https://a' },
+          { port: 7070, baseUrl: 'https://b' },
+        ],
+        3001,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects collision with the gateway port', () => {
+    expect(() =>
+      validateProxyPorts([{ port: 3001, baseUrl: 'https://a' }], 3001),
+    ).toThrow('collides with the main gateway port');
+  });
+
+  it('rejects two proxies on the same port', () => {
+    expect(() =>
+      validateProxyPorts(
+        [
+          { port: 6060, baseUrl: 'https://a' },
+          { port: 6060, baseUrl: 'https://b' },
+        ],
+        3001,
+      ),
+    ).toThrow('Duplicate proxy port');
+  });
+
+  it('accepts an empty array', () => {
+    expect(() => validateProxyPorts([], 3001)).not.toThrow();
+  });
+});

--- a/server/src/domains/request-proxy/config/proxy_config.ts
+++ b/server/src/domains/request-proxy/config/proxy_config.ts
@@ -1,0 +1,73 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { ProxyConfig, ProxyMapping } from '../types/proxy_types.js';
+import { loadJsonConfig } from '../../../lib/json_config_loader.js';
+
+function isValidPort(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+function isValidBaseUrl(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isValidHeaders(value: unknown): value is Record<string, string> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>).every((v) => typeof v === 'string');
+}
+
+function isProxyMapping(value: unknown): value is ProxyMapping {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as Record<string, unknown>;
+  if (!isValidPort(m.port)) return false;
+  if (!isValidBaseUrl(m.baseUrl)) return false;
+  if (m.headers !== undefined && !isValidHeaders(m.headers)) return false;
+  return true;
+}
+
+function isProxyConfig(value: unknown): value is ProxyConfig {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (!Array.isArray(v.proxies)) return false;
+  return v.proxies.every(isProxyMapping);
+}
+
+/**
+ * Check that no two proxy mappings share a port, and that none collides with
+ * the main gateway port. Throws a descriptive error on the first collision.
+ */
+export function validateProxyPorts(proxies: ProxyMapping[], gatewayPort: number): void {
+  const seen = new Map<number, number>();
+  for (const [index, proxy] of proxies.entries()) {
+    if (proxy.port === gatewayPort) {
+      throw new Error(
+        `Proxy port ${proxy.port} (proxies[${index}]) collides with the main gateway port (${gatewayPort}).`,
+      );
+    }
+    const prior = seen.get(proxy.port);
+    if (prior !== undefined) {
+      throw new Error(
+        `Duplicate proxy port ${proxy.port} (proxies[${prior}] and proxies[${index}]).`,
+      );
+    }
+    seen.set(proxy.port, index);
+  }
+}
+
+/**
+ * Load and validate the proxy config file. Returns `undefined` when the file
+ * does not exist — the proxy feature is then disabled. Throws when the file
+ * exists but is malformed.
+ */
+export function loadProxyConfig(configPath: string | undefined): ProxyConfig | undefined {
+  if (!configPath) return undefined;
+  const resolved = resolve(configPath);
+  if (!existsSync(resolved)) return undefined;
+  return loadJsonConfig(resolved, isProxyConfig);
+}

--- a/server/src/domains/request-proxy/config/proxy_config.ts
+++ b/server/src/domains/request-proxy/config/proxy_config.ts
@@ -28,6 +28,7 @@ function isProxyMapping(value: unknown): value is ProxyMapping {
   if (!isValidPort(m.port)) return false;
   if (!isValidBaseUrl(m.baseUrl)) return false;
   if (m.headers !== undefined && !isValidHeaders(m.headers)) return false;
+  if (m.host !== undefined && (typeof m.host !== 'string' || m.host.length === 0)) return false;
   return true;
 }
 

--- a/server/src/domains/request-proxy/service/proxy_server.test.ts
+++ b/server/src/domains/request-proxy/service/proxy_server.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, afterEach, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { createProxyServers, type ProxyServers } from './proxy_server.js';
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+/** Spin up a fake upstream that records every request it receives. */
+function createUpstream(): Promise<{ server: http.Server; port: number; captured: CapturedRequest[] }> {
+  return new Promise((resolve) => {
+    const captured: CapturedRequest[] = [];
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+      req.on('end', () => {
+        captured.push({
+          method: req.method ?? '',
+          url: req.url ?? '',
+          headers: req.headers,
+          body,
+        });
+        res.writeHead(200, { 'Content-Type': 'application/json', 'x-upstream-marker': 'yes' });
+        res.end(JSON.stringify({ ok: true, echoedUrl: req.url }));
+      });
+    });
+    server.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ server, port, captured });
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+async function findFreePort(): Promise<number> {
+  const throwaway = http.createServer();
+  await new Promise<void>((r) => throwaway.listen(0, r));
+  const { port } = throwaway.address() as AddressInfo;
+  await closeServer(throwaway);
+  return port;
+}
+
+describe('createProxyServers', () => {
+  let upstream: { server: http.Server; port: number; captured: CapturedRequest[] };
+  let proxies: ProxyServers | undefined;
+
+  beforeAll(async () => {
+    upstream = await createUpstream();
+  });
+
+  afterAll(async () => {
+    await closeServer(upstream.server);
+  });
+
+  afterEach(async () => {
+    if (proxies) {
+      await proxies.stop();
+      proxies = undefined;
+    }
+    upstream.captured.length = 0;
+  });
+
+  it('forwards request path and body to the upstream', async () => {
+    const proxyPort = await findFreePort();
+
+    proxies = createProxyServers([
+      { port: proxyPort, baseUrl: `http://127.0.0.1:${upstream.port}` },
+    ]);
+    await proxies.start();
+
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/v1/chat/completions?x=1`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hello: 'world' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-upstream-marker')).toBe('yes');
+    const json = await res.json() as { ok: boolean; echoedUrl: string };
+    expect(json.ok).toBe(true);
+    expect(json.echoedUrl).toBe('/v1/chat/completions?x=1');
+
+    expect(upstream.captured).toHaveLength(1);
+    const captured = upstream.captured[0];
+    expect(captured.method).toBe('POST');
+    expect(captured.url).toBe('/v1/chat/completions?x=1');
+    expect(captured.body).toBe(JSON.stringify({ hello: 'world' }));
+  });
+
+  it('injects configured headers and overrides caller-supplied values of the same name', async () => {
+    const proxyPort = await findFreePort();
+
+    proxies = createProxyServers([
+      {
+        port: proxyPort,
+        baseUrl: `http://127.0.0.1:${upstream.port}`,
+        headers: {
+          'x-injected': 'from-proxy',
+          authorization: 'Bearer configured-key',
+        },
+      },
+    ]);
+    await proxies.start();
+
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/ping`, {
+      headers: {
+        authorization: 'Bearer caller-key',
+        'x-caller-only': 'kept',
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const captured = upstream.captured[0];
+    expect(captured.headers['x-injected']).toBe('from-proxy');
+    expect(captured.headers['authorization']).toBe('Bearer configured-key');
+    expect(captured.headers['x-caller-only']).toBe('kept');
+  });
+
+  it('returns 502 when the upstream is unreachable', async () => {
+    const proxyPort = await findFreePort();
+    const deadPort = await findFreePort();
+
+    proxies = createProxyServers([
+      { port: proxyPort, baseUrl: `http://127.0.0.1:${deadPort}` },
+    ]);
+    await proxies.start();
+
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/whatever`);
+    expect(res.status).toBe(502);
+    const json = await res.json() as { error: string };
+    expect(json.error).toBe('bad_gateway');
+  });
+
+  it('starts and stops multiple listeners independently', async () => {
+    const port1 = await findFreePort();
+    const port2 = await findFreePort();
+
+    proxies = createProxyServers([
+      { port: port1, baseUrl: `http://127.0.0.1:${upstream.port}` },
+      { port: port2, baseUrl: `http://127.0.0.1:${upstream.port}` },
+    ]);
+    await proxies.start();
+
+    const [r1, r2] = await Promise.all([
+      fetch(`http://127.0.0.1:${port1}/one`),
+      fetch(`http://127.0.0.1:${port2}/two`),
+    ]);
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+
+    await proxies.stop();
+    proxies = undefined;
+
+    await expect(fetch(`http://127.0.0.1:${port1}/one`)).rejects.toThrow();
+    await expect(fetch(`http://127.0.0.1:${port2}/two`)).rejects.toThrow();
+  });
+
+  it('start() rejects when the port is already in use', async () => {
+    const squatter = http.createServer();
+    await new Promise<void>((r) => squatter.listen(0, r));
+    const port = (squatter.address() as AddressInfo).port;
+
+    proxies = createProxyServers([
+      { port, baseUrl: `http://127.0.0.1:${upstream.port}` },
+    ]);
+
+    await expect(proxies.start()).rejects.toThrow();
+    await closeServer(squatter);
+    proxies = undefined;
+  });
+});

--- a/server/src/domains/request-proxy/service/proxy_server.test.ts
+++ b/server/src/domains/request-proxy/service/proxy_server.test.ts
@@ -164,7 +164,7 @@ describe('createProxyServers', () => {
 
   it('start() rejects when the port is already in use', async () => {
     const squatter = http.createServer();
-    await new Promise<void>((r) => squatter.listen(0, r));
+    await new Promise<void>((r) => squatter.listen(0, '127.0.0.1', r));
     const port = (squatter.address() as AddressInfo).port;
 
     proxies = createProxyServers([
@@ -172,6 +172,85 @@ describe('createProxyServers', () => {
     ]);
 
     await expect(proxies.start()).rejects.toThrow();
+    await closeServer(squatter);
+    proxies = undefined;
+  });
+
+  it('binds to loopback (127.0.0.1) by default so a credentialed proxy is not network-exposed', async () => {
+    const proxyPort = await findFreePort();
+
+    proxies = createProxyServers([
+      { port: proxyPort, baseUrl: `http://127.0.0.1:${upstream.port}` },
+    ]);
+    await proxies.start();
+
+    // A second listener on the same port but bound to a *different*
+    // interface must succeed — proves the first listener is NOT on 0.0.0.0.
+    const coexistence = http.createServer((_req, res) => res.end('coexists'));
+    await new Promise<void>((resolve, reject) => {
+      coexistence.once('error', reject);
+      coexistence.once('listening', () => resolve());
+      coexistence.listen(proxyPort, '::1');
+    });
+    await closeServer(coexistence);
+  });
+
+  it('honors an explicit host when set to 0.0.0.0', async () => {
+    const proxyPort = await findFreePort();
+
+    proxies = createProxyServers([
+      {
+        port: proxyPort,
+        baseUrl: `http://127.0.0.1:${upstream.port}`,
+        host: '0.0.0.0',
+      },
+    ]);
+    await proxies.start();
+
+    // Reachable via loopback (which is within 0.0.0.0) — proves the bind
+    // succeeded on the requested host.
+    const res = await fetch(`http://127.0.0.1:${proxyPort}/ok`);
+    expect(res.status).toBe(200);
+  });
+
+  it('start() rolls back already-started listeners when a later one fails', async () => {
+    const port1 = await findFreePort();
+    const squatter = http.createServer();
+    await new Promise<void>((r) => squatter.listen(0, '127.0.0.1', r));
+    const port2 = (squatter.address() as AddressInfo).port;
+
+    proxies = createProxyServers([
+      { port: port1, baseUrl: `http://127.0.0.1:${upstream.port}` },
+      { port: port2, baseUrl: `http://127.0.0.1:${upstream.port}` },
+    ]);
+
+    await expect(proxies.start()).rejects.toThrow();
+    proxies = undefined;
+
+    // Rollback proof: port1 is no longer bound by our proxy — a fresh
+    // listener can grab it immediately.
+    const claimant = http.createServer();
+    await new Promise<void>((resolve, reject) => {
+      claimant.once('error', reject);
+      claimant.once('listening', () => resolve());
+      claimant.listen(port1, '127.0.0.1');
+    });
+    await closeServer(claimant);
+    await closeServer(squatter);
+  });
+
+  it('stop() tolerates listeners that never bound', async () => {
+    const squatter = http.createServer();
+    await new Promise<void>((r) => squatter.listen(0, '127.0.0.1', r));
+    const squattedPort = (squatter.address() as AddressInfo).port;
+
+    proxies = createProxyServers([
+      { port: squattedPort, baseUrl: `http://127.0.0.1:${upstream.port}` },
+    ]);
+
+    await expect(proxies.start()).rejects.toThrow();
+    // stop() must not throw even though nothing ever bound.
+    await expect(proxies.stop()).resolves.toBeUndefined();
     await closeServer(squatter);
     proxies = undefined;
   });

--- a/server/src/domains/request-proxy/service/proxy_server.ts
+++ b/server/src/domains/request-proxy/service/proxy_server.ts
@@ -1,0 +1,101 @@
+import http from 'node:http';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+import type { ProxyMapping } from '../types/proxy_types.js';
+import { createChildLogger } from '../../../lib/logger.js';
+
+const log = createChildLogger('proxy');
+
+export interface ProxyServers {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+/** Opaque handle on one running listener — exported for testability. */
+interface RunningProxy {
+  mapping: ProxyMapping;
+  server: http.Server;
+}
+
+function buildProxyServer(mapping: ProxyMapping): http.Server {
+  const middleware = createProxyMiddleware({
+    target: mapping.baseUrl,
+    changeOrigin: true,
+    logger: log,
+    on: {
+      proxyReq: (proxyReq) => {
+        if (!mapping.headers) return;
+        for (const [name, value] of Object.entries(mapping.headers)) {
+          proxyReq.setHeader(name, value);
+        }
+      },
+      error: (err, _req, res) => {
+        log.error({ err, port: mapping.port, baseUrl: mapping.baseUrl }, 'Proxy upstream error');
+        // res can be a ServerResponse or a Socket (on WebSocket upgrades).
+        // Only ServerResponse has writeHead/end that make sense for HTTP errors.
+        if ('writeHead' in res && !res.headersSent) {
+          res.writeHead(502, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'bad_gateway', message: 'Upstream request failed' }));
+        }
+      },
+    },
+  });
+
+  return http.createServer((req, res) => {
+    // http-proxy-middleware returns a Promise<void>; unhandled rejections
+    // here would log via the `error` handler above, but we guard explicitly.
+    middleware(req, res).catch((err: unknown) => {
+      log.error({ err, port: mapping.port }, 'Proxy middleware threw');
+      if (!res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'bad_gateway', message: 'Proxy handler failed' }));
+      }
+    });
+  });
+}
+
+function listenAsync(server: http.Server, port: number): Promise<void> {
+  return new Promise((resolveListen, rejectListen) => {
+    const onError = (err: Error) => {
+      server.off('listening', onListening);
+      rejectListen(err);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolveListen();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port);
+  });
+}
+
+function closeAsync(server: http.Server): Promise<void> {
+  return new Promise((resolveClose) => {
+    server.close(() => resolveClose());
+  });
+}
+
+/**
+ * Build proxy servers for a set of mappings. Listeners are NOT bound until
+ * `start()` is called so that `createApp()` stays synchronous and config
+ * errors surface before any socket is opened.
+ */
+export function createProxyServers(mappings: ProxyMapping[]): ProxyServers {
+  const running: RunningProxy[] = mappings.map((mapping) => ({
+    mapping,
+    server: buildProxyServer(mapping),
+  }));
+
+  async function start(): Promise<void> {
+    for (const { mapping, server } of running) {
+      await listenAsync(server, mapping.port);
+      log.info({ port: mapping.port, baseUrl: mapping.baseUrl }, 'Proxy listening');
+    }
+  }
+
+  async function stop(): Promise<void> {
+    await Promise.all(running.map(({ server }) => closeAsync(server)));
+  }
+
+  return { start, stop };
+}

--- a/server/src/domains/request-proxy/service/proxy_server.ts
+++ b/server/src/domains/request-proxy/service/proxy_server.ts
@@ -1,6 +1,7 @@
 import http from 'node:http';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import type { ProxyMapping } from '../types/proxy_types.js';
+import { DEFAULT_PROXY_HOST } from '../types/proxy_types.js';
 import { createChildLogger } from '../../../lib/logger.js';
 
 const log = createChildLogger('proxy');
@@ -10,7 +11,6 @@ export interface ProxyServers {
   stop(): Promise<void>;
 }
 
-/** Opaque handle on one running listener — exported for testability. */
 interface RunningProxy {
   mapping: ProxyMapping;
   server: http.Server;
@@ -41,8 +41,6 @@ function buildProxyServer(mapping: ProxyMapping): http.Server {
   });
 
   return http.createServer((req, res) => {
-    // http-proxy-middleware returns a Promise<void>; unhandled rejections
-    // here would log via the `error` handler above, but we guard explicitly.
     middleware(req, res).catch((err: unknown) => {
       log.error({ err, port: mapping.port }, 'Proxy middleware threw');
       if (!res.headersSent) {
@@ -53,7 +51,7 @@ function buildProxyServer(mapping: ProxyMapping): http.Server {
   });
 }
 
-function listenAsync(server: http.Server, port: number): Promise<void> {
+function listenAsync(server: http.Server, port: number, host: string): Promise<void> {
   return new Promise((resolveListen, rejectListen) => {
     const onError = (err: Error) => {
       server.off('listening', onListening);
@@ -65,20 +63,36 @@ function listenAsync(server: http.Server, port: number): Promise<void> {
     };
     server.once('error', onError);
     server.once('listening', onListening);
-    server.listen(port);
+    server.listen(port, host);
   });
 }
 
 function closeAsync(server: http.Server): Promise<void> {
   return new Promise((resolveClose) => {
+    if (!server.listening) {
+      resolveClose();
+      return;
+    }
     server.close(() => resolveClose());
   });
+}
+
+async function bestEffortClose(server: http.Server): Promise<void> {
+  try {
+    await closeAsync(server);
+  } catch (err) {
+    log.warn({ err }, 'Error while closing proxy listener');
+  }
 }
 
 /**
  * Build proxy servers for a set of mappings. Listeners are NOT bound until
  * `start()` is called so that `createApp()` stays synchronous and config
  * errors surface before any socket is opened.
+ *
+ * `start()` is all-or-nothing: if a later listener fails to bind, already-
+ * started listeners are closed before the error is rethrown, so the caller
+ * never observes a partially-started set.
  */
 export function createProxyServers(mappings: ProxyMapping[]): ProxyServers {
   const running: RunningProxy[] = mappings.map((mapping) => ({
@@ -87,14 +101,29 @@ export function createProxyServers(mappings: ProxyMapping[]): ProxyServers {
   }));
 
   async function start(): Promise<void> {
-    for (const { mapping, server } of running) {
-      await listenAsync(server, mapping.port);
-      log.info({ port: mapping.port, baseUrl: mapping.baseUrl }, 'Proxy listening');
+    const started: RunningProxy[] = [];
+    try {
+      for (const entry of running) {
+        const host = entry.mapping.host ?? DEFAULT_PROXY_HOST;
+        await listenAsync(entry.server, entry.mapping.port, host);
+        started.push(entry);
+        log.info(
+          { port: entry.mapping.port, host, baseUrl: entry.mapping.baseUrl },
+          'Proxy listening',
+        );
+      }
+    } catch (err) {
+      // Roll back any listeners that did come up before rethrowing, so the
+      // caller sees an all-or-nothing startup.
+      await Promise.all(started.map(({ server }) => bestEffortClose(server)));
+      throw err;
     }
   }
 
   async function stop(): Promise<void> {
-    await Promise.all(running.map(({ server }) => closeAsync(server)));
+    // Best-effort close: a listener that never bound (e.g. because start()
+    // failed partway) must not prevent cleanup of the rest.
+    await Promise.all(running.map(({ server }) => bestEffortClose(server)));
   }
 
   return { start, stop };

--- a/server/src/domains/request-proxy/types/proxy_types.ts
+++ b/server/src/domains/request-proxy/types/proxy_types.ts
@@ -1,0 +1,15 @@
+/**
+ * A single transparent-proxy mapping. One mapping = one listener on its own
+ * port that forwards every incoming request to `baseUrl`, preserving the
+ * request path, method, query string and body, and injecting the configured
+ * `headers` on the outgoing request.
+ */
+export interface ProxyMapping {
+  port: number;
+  baseUrl: string;
+  headers?: Record<string, string>;
+}
+
+export interface ProxyConfig {
+  proxies: ProxyMapping[];
+}

--- a/server/src/domains/request-proxy/types/proxy_types.ts
+++ b/server/src/domains/request-proxy/types/proxy_types.ts
@@ -3,12 +3,19 @@
  * port that forwards every incoming request to `baseUrl`, preserving the
  * request path, method, query string and body, and injecting the configured
  * `headers` on the outgoing request.
+ *
+ * `host` controls the bind address. Defaults to `127.0.0.1` so a
+ * credentialed proxy is not inadvertently exposed to the network — set it
+ * explicitly (e.g. `"0.0.0.0"`) to opt into broader binding.
  */
 export interface ProxyMapping {
   port: number;
   baseUrl: string;
   headers?: Record<string, string>;
+  host?: string;
 }
+
+export const DEFAULT_PROXY_HOST = '127.0.0.1';
 
 export interface ProxyConfig {
   proxies: ProxyMapping[];


### PR DESCRIPTION
## Summary

Adds a transparent HTTP proxy capability to lucifer-gate as a new `request-proxy` domain. One or more listeners, each on its own configurable port, forward every incoming request to a configured upstream while injecting a fixed set of outgoing headers server-side. Primary use case: put an AI API (e.g. OpenAI) behind a local port so callers never need to know the upstream URL or hold the credential.

Closes #16

## What changed

- **New domain** `server/src/domains/request-proxy/` with `types/`, `config/`, and `service/` layers. No `api/` layer — the proxy exposes no surface on the main app.
- **New config file** `proxy-config.json` alongside `lucifer.json`. File absent → feature disabled; present with `{"proxies": []}` → enabled with no listeners.
- **Library**: `http-proxy-middleware@^3.0.5` (well-maintained, Express-compatible, wraps `http-proxy`). No hand-rolled proxy logic.
- **Header semantics**: configured headers overwrite caller-supplied headers of the same name, so callers cannot spoof or override the configured credential.
- **Port collisions** (with the main gateway port or between proxies) fail fast at startup.
- **Lifecycle** wired into `createApp()` — listeners bind on `start()` and close on `stop()`.
- **`lucifer-gate --init`** now also writes a starter empty `proxy-config.json`.

### Example

```json
{
  "proxies": [
    {
      "port": 6060,
      "baseUrl": "https://api.openai.com",
      "headers": { "Authorization": "Bearer sk-..." }
    }
  ]
}
```

`POST http://localhost:6060/v1/chat/completions` → `POST https://api.openai.com/v1/chat/completions` with the `Authorization` header injected.

## Docs

- New spec `docs/specs/transparent-proxy.md`
- ADR-010 in `docs/context/DECISIONS.md` (domain split rationale, config-file rationale, header-overwrite semantics)
- New domain row in `docs/architecture/ARCHITECTURE.md`
- Spec index updated
- README section under the existing config docs

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 262 tests pass (26 files), including 20 new tests for the proxy domain
- [x] `npm run build` — dependency structure check + `tsc -p tsconfig.server.json` both pass
- [ ] Reviewer spot-check: smoke test against a real upstream (any JSON API) using a fresh `config/proxy-config.json`
- [ ] Reviewer spot-check: confirm legacy installs (no `proxy-config.json`) continue to boot unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)