### PR TITLE
chore(security): Dependabot triage 2026-04-17

### DIFF
--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: dependabot
+description: >
+  Triage and fix Dependabot security alerts for this repository using `gh` and
+  `npm`. Use when the user asks to review the Dependabot security tab, clear
+  open alerts, merge Dependabot PRs, or explain why an alert is safe to
+  dismiss. Pairs with the `gh-cli-guide` skill for the underlying API calls
+  and with `github-pr-fixer` when a Dependabot PR needs to be driven to green.
+metadata:
+  author: claude
+  version: 1.0.0
+  category: workflow
+---
+
+# Skill: Dependabot
+
+Inspect and resolve the security alerts at
+`https://github.com/<owner>/<repo>/security/dependabot` by classifying each
+open alert and picking the smallest fix that closes it. Read-only inspection
+first, then the narrowest possible change.
+
+## Inputs and assumptions
+
+- `gh` is authenticated with `security_events` (or `repo`) scope so
+  `/dependabot/alerts` is reachable. Verify with `gh auth status`.
+- The repo's default branch is where fixes land (check with
+  `gh repo view --json defaultBranchRef`).
+- For Node projects the manifest is `package.json` / `package-lock.json` and
+  `npm audit --json` complements the GitHub view.
+- The relevant `gh` command patterns live in
+  [.claude/skills/gh-cli-guide/SKILL.md](../gh-cli-guide/SKILL.md) — this
+  skill assumes you already know how to call `gh api`.
+
+## Step 1: Inventory open alerts
+
+```bash
+gh api repos/<owner>/<repo>/dependabot/alerts --paginate \
+  --jq '.[] | select(.state=="open") | {
+    number, severity: .security_advisory.severity,
+    package: .dependency.package.name,
+    manifest: .dependency.manifest_path,
+    scope: .dependency.scope,
+    summary: .security_advisory.summary,
+    fixed_in: (.security_advisory.vulnerabilities[]
+                | select(.package.name==.dependency.package.name)
+                | .first_patched_version.identifier) // null,
+    url: .html_url
+  }'
+```
+
+`scope` is `runtime` or `development`. A `development`-only alert has
+different blast radius — record it, but do not over-invest.
+
+Also list any Dependabot-authored PRs already open:
+
+```bash
+gh pr list --state open --json number,title,author,statusCheckRollup \
+  --jq '.[] | select(.author.login=="app/dependabot") |
+    {number,title,checks: [.statusCheckRollup[].conclusion]}'
+```
+
+## Step 2: Classify each alert
+
+| Signal | Treatment |
+|--------|-----------|
+| Existing Dependabot PR, green checks | Merge it (Step 4a) |
+| Direct dependency listed in `package.json` | Bump the declared range (Step 4b) |
+| Transitive, patched version exists | Add an `overrides` entry (Step 4c) |
+| Transitive, no safe fix and dev-only | Document + dismiss with reason (Step 4d) |
+| Not applicable / test fixture / duplicate | Dismiss with the right reason (Step 4d) |
+
+Get the full advisory for an alert before deciding:
+
+```bash
+gh api repos/<owner>/<repo>/dependabot/alerts/<N> \
+  --jq '{summary: .security_advisory.summary,
+         cvss: .security_advisory.cvss.score,
+         vulnerable_range: .security_vulnerability.vulnerable_version_range,
+         first_patched: .security_vulnerability.first_patched_version.identifier,
+         description: .security_advisory.description}'
+```
+
+Cross-check with `npm audit --json` so you catch alerts that share a single
+underlying bump. One Dependabot alert per CVE, but one dependency bump often
+closes several alerts at once.
+
+## Step 3: Branch and open the PR immediately
+
+Do **not** wait for local validation before opening the PR. Use the PR as the
+discussion board with the alert owner — every subsequent decision (which
+bumps to take, which alerts to dismiss, whether to cross a major) is agreed
+in PR comments, not in the console.
+
+```bash
+git checkout -b fix/dependabot-<short-label>
+# No code changes yet — push an empty commit so the PR has somewhere to land.
+git commit --allow-empty -m "chore(security): open Dependabot triage PR"
+git push -u origin fix/dependabot-<short-label>
+
+gh pr create --draft --title "chore(security): Dependabot triage <date>" \
+  --body-file <(cat <<'EOF'
+## Plan
+
+Classified alerts (see table) and the fix I intend for each. Nothing is
+applied yet — this PR is the discussion board. Reply inline or as a PR
+comment to approve, redirect, or block any row.
+
+| # | Severity | Package | Manifest | Scope | Intended fix |
+|---|----------|---------|----------|-------|--------------|
+| 20 | medium | axios | package-lock.json | dev | override to ^1.x / dismiss if major breaks tests |
+| ... | | | | | |
+
+## Checkpoints
+
+- [ ] Plan approved in comments
+- [ ] Fixes applied and pushed
+- [ ] `npm audit`, lint, test, build all green
+- [ ] Security tab reconciled
+EOF
+)
+```
+
+Record the PR number and URL — the remaining steps poll it.
+
+## Step 4: Poll the PR for instructions
+
+Until the PR is closed, poll every 5 minutes for new comments or review
+feedback. Do not silently apply fixes between polls — the PR *is* the
+approval surface.
+
+```bash
+# New issue-level comments on the PR
+gh api repos/<owner>/<repo>/issues/<N>/comments \
+  --jq '.[] | {id, user: .user.login, created_at, body: (.body[:300])}'
+
+# Review-level comments (line-attached feedback)
+gh api repos/<owner>/<repo>/pulls/<N>/comments \
+  --jq '.[] | {id, user: .user.login, path, line, body}'
+```
+
+Keep an in-memory watermark (highest comment id seen) so repeated polls do
+not redo work. Act only when the owner explicitly approves a row, asks for a
+change, or tells you to close the PR. "Looks good" from a bot is **not**
+approval — wait for the human.
+
+If five poll cycles pass with no new input, post a single nudge comment
+pointing at the plan table, then keep polling. Do not nag more than once
+per hour.
+
+## Step 5: Apply fixes
+
+### 5a. Merge a clean Dependabot PR
+
+```bash
+gh pr checks <N> --watch --fail-fast
+gh pr merge <N> --squash --delete-branch
+```
+
+Reload the alert list afterwards — GitHub closes the matching alerts
+automatically once the PR merges.
+
+### 5b. Bump a direct dependency
+
+Edit `package.json` to the `first_patched_version` (or higher, within the
+current major). Then:
+
+```bash
+npm install
+npm audit --json | jq '.metadata.vulnerabilities'
+npm run lint && npm run test && npm run build
+```
+
+If the patch is behind a major bump, confirm with the user before crossing
+the major boundary.
+
+### 5c. Add an npm override for a transitive
+
+Only use this when a direct bump is not available. Keep overrides tightly
+scoped — prefer the narrowest version range that closes the alert.
+
+```jsonc
+// package.json
+"overrides": {
+  "body-parser": "^1.20.3",
+  "cookie": "^0.7.0"
+}
+```
+
+Run `npm install`, then `npm audit` + the full `npm run lint && npm run test
+&& npm run build` pipeline. If a test breaks, widen the override one minor
+version at a time; do not silently drop it.
+
+### 5d. Dismiss an alert with a reason
+
+Only when the alert is genuinely inapplicable or the fix is impossible.
+Record the reason in the PR description too.
+
+```bash
+gh api -X PATCH repos/<owner>/<repo>/dependabot/alerts/<N> \
+  -f state=dismissed \
+  -f dismissed_reason='tolerable_risk' \
+  -f dismissed_comment='Dev-only transitive via telegram-test-api 4.2.1. Latest upstream still pins axios 0.27. Risk contained to the test harness.'
+```
+
+Valid `dismissed_reason` values: `fix_started`, `inaccurate`, `no_bandwidth`,
+`not_used`, `tolerable_risk`.
+
+## Step 6: Validate and ship
+
+1. `npm audit` — confirm the counts match what you expected to fix.
+2. `gh api repos/<owner>/<repo>/dependabot/alerts --jq '[.[] | select(.state=="open")] | length'` — compare before/after.
+3. Flip the PR from draft to ready (`gh pr ready <N>`) and update the body
+   with the final table: `alert # → fix (bump / override / merged #X / dismissed)`.
+4. Keep polling until the owner approves the merge or closes the PR.
+5. After merge, re-run the inventory query to confirm the GitHub security
+   tab is actually green.
+
+## Guardrails
+
+- Do not downgrade a dependency because `npm audit` suggests an older "fix"
+  version. That happens when the advisory's auto-fix graph is stale — prefer
+  the `first_patched_version` from the advisory or the current major.
+- Do not add `npm audit fix --force` to CI. A force-fix can cross majors on
+  production deps without review.
+- Do not dismiss runtime alerts without explicit user approval.
+- Do not bundle a security fix with an unrelated feature change.
+- Do not silently remove an `overrides` entry — leave a comment (or commit
+  message) that says which alert it resolved, so a later bump can retire it.
+
+## Related skills
+
+- [gh-cli-guide](../gh-cli-guide/SKILL.md) — canonical `gh` command patterns,
+  including the Dependabot / security endpoints.
+- [github-pr-fixer](../github-pr-fixer/SKILL.md) — drive a Dependabot PR to
+  green if its checks fail.
+- [small-change](../small-change/SKILL.md) — preferred wrapper workflow when
+  the fix is a scoped dependency bump.

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -266,7 +266,10 @@ Once the local pipeline is green and the fixes are pushed:
    (bump / override / merged #X / dismissed)`) and flip it to ready with
    `gh pr ready <N>`.
 4. **Stop the 5-minute poll.** Call `CronDelete` with the job id from
-   Step 4 so the dependabot skill is no longer polling.
+   Step 4 so the dependabot skill is no longer polling. CI checks kicked
+   off by the push do **not** need 5-minute polling — `github-pr-fixer`
+   will wait on them with `gh pr checks <N> --watch --fail-fast`, which
+   blocks until every check has a terminal state.
 5. Post a hand-off comment on the PR: "Local pipeline green, handing off
    to `github-pr-fixer`."
 6. Invoke the `github-pr-fixer` skill with the PR number. It takes

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -16,8 +16,24 @@ metadata:
 
 Inspect and resolve the security alerts at
 `https://github.com/<owner>/<repo>/security/dependabot` by classifying each
-open alert and picking the smallest fix that closes it. Read-only inspection
-first, then the narrowest possible change.
+open alert and picking the smallest fix that closes it.
+
+## Operating contract — zero console interaction
+
+This skill runs **without asking the console anything**. From the moment it
+starts, every decision surface is the PR:
+
+- The plan is posted as the PR body.
+- Every clarification the skill would otherwise ask the user is posted as a
+  PR comment instead.
+- The skill self-enters a 5-minute polling loop and keeps going until the PR
+  is merged or closed.
+- If you hit an ambiguous situation, your options are: (a) make the safe
+  default and flag it in a PR comment, or (b) post the question to the PR
+  and wait for the next poll. Never return to the console to ask.
+
+The only console output is a one-line handoff: the PR URL plus the polling
+cadence. After that, the skill is silent until the PR closes.
 
 ## Inputs and assumptions
 
@@ -122,11 +138,21 @@ EOF
 
 Record the PR number and URL — the remaining steps poll it.
 
-## Step 4: Poll the PR for instructions
+## Step 4: Self-enter the 5-minute polling loop
 
-Until the PR is closed, poll every 5 minutes for new comments or review
-feedback. Do not silently apply fixes between polls — the PR *is* the
-approval surface.
+The skill must start the loop itself. Do not print instructions asking the
+user to run `/loop`. Invoke the `loop` skill directly, passing a polling
+command that re-enters this skill's poll phase:
+
+```
+Skill("loop", args="5m dependabot poll PR <N>")
+```
+
+The `loop` skill will fire the polling command every 5 minutes, including
+the first cycle immediately after the PR is opened. The skill is now
+hands-free — the console can be closed.
+
+### What each poll cycle does
 
 ```bash
 # New issue-level comments on the PR
@@ -136,16 +162,40 @@ gh api repos/<owner>/<repo>/issues/<N>/comments \
 # Review-level comments (line-attached feedback)
 gh api repos/<owner>/<repo>/pulls/<N>/comments \
   --jq '.[] | {id, user: .user.login, path, line, body}'
+
+# Review-level state (approved, requested changes, etc.)
+gh api repos/<owner>/<repo>/pulls/<N>/reviews \
+  --jq '.[] | {id, user: .user.login, state, submitted_at, body}'
+
+# Current PR state — stop the loop if closed or merged
+gh pr view <N> --json state,mergedAt,closedAt
 ```
 
-Keep an in-memory watermark (highest comment id seen) so repeated polls do
-not redo work. Act only when the owner explicitly approves a row, asks for a
-change, or tells you to close the PR. "Looks good" from a bot is **not**
-approval — wait for the human.
+Persist a watermark (highest comment id seen) in a scratch file inside the
+PR branch, e.g. `.dependabot-watermark`, so repeated polls do not redo
+work. Commit the watermark updates to the branch — this keeps state across
+loop iterations even if the skill process restarts.
 
-If five poll cycles pass with no new input, post a single nudge comment
-pointing at the plan table, then keep polling. Do not nag more than once
-per hour.
+### Decision rules inside the loop
+
+| Signal in the poll | Action |
+|--------------------|--------|
+| New comment approving a row | Apply that row's fix (Step 5), push, comment back with the commit SHA |
+| New comment redirecting a row | Update the PR body plan table to match, then apply the new direction |
+| New comment blocking a row | Mark that row as skipped in the plan and move on |
+| Line-level review comment on a file change | Amend the affected file, push, reply to the comment with the commit SHA |
+| PR closed with no merge | Exit the loop, delete the branch, do nothing else |
+| PR merged | Reconcile the security tab (Step 6), then exit the loop |
+| No new signal for 60 min (12 cycles) | Post one nudge comment pointing at unresolved rows. Do not nag again before another 60 minutes |
+
+Never ask the console a question. If the skill is blocked by missing
+information, it must post the question as a PR comment and keep polling.
+
+### Stopping the loop
+
+The loop exits when `gh pr view` reports `state == "MERGED"` or
+`state == "CLOSED"`. On exit, run Step 6 if merged, otherwise leave the
+branch for the user to inspect.
 
 ## Step 5: Apply fixes
 
@@ -170,8 +220,9 @@ npm audit --json | jq '.metadata.vulnerabilities'
 npm run lint && npm run test && npm run build
 ```
 
-If the patch is behind a major bump, confirm with the user before crossing
-the major boundary.
+If the patch is behind a major bump, do not apply it silently. Post a PR
+comment with the proposed bump, affected callers, and the known breaking
+changes, and wait for explicit approval in a later poll cycle.
 
 ### 5c. Add an npm override for a transitive
 
@@ -222,7 +273,8 @@ Valid `dismissed_reason` values: `fix_started`, `inaccurate`, `no_bandwidth`,
   the `first_patched_version` from the advisory or the current major.
 - Do not add `npm audit fix --force` to CI. A force-fix can cross majors on
   production deps without review.
-- Do not dismiss runtime alerts without explicit user approval.
+- Do not dismiss runtime alerts without explicit approval posted **in a PR
+  comment**. Never use the console channel to confirm a dismissal.
 - Do not bundle a security fix with an unrelated feature change.
 - Do not silently remove an `overrides` entry — leave a comment (or commit
   message) that says which alert it resolved, so a later bump can retire it.

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -256,15 +256,24 @@ gh api -X PATCH repos/<owner>/<repo>/dependabot/alerts/<N> \
 Valid `dismissed_reason` values: `fix_started`, `inaccurate`, `no_bandwidth`,
 `not_used`, `tolerable_risk`.
 
-## Step 6: Validate and ship
+## Step 6: Hand off to github-pr-fixer
+
+Once the local pipeline is green and the fixes are pushed:
 
 1. `npm audit` — confirm the counts match what you expected to fix.
 2. `gh api repos/<owner>/<repo>/dependabot/alerts --jq '[.[] | select(.state=="open")] | length'` — compare before/after.
-3. Flip the PR from draft to ready (`gh pr ready <N>`) and update the body
-   with the final table: `alert # → fix (bump / override / merged #X / dismissed)`.
-4. Keep polling until the owner approves the merge or closes the PR.
-5. After merge, re-run the inventory query to confirm the GitHub security
-   tab is actually green.
+3. Update the PR body with the final resolution table (`alert # → fix
+   (bump / override / merged #X / dismissed)`) and flip it to ready with
+   `gh pr ready <N>`.
+4. **Stop the 5-minute poll.** Call `CronDelete` with the job id from
+   Step 4 so the dependabot skill is no longer polling.
+5. Post a hand-off comment on the PR: "Local pipeline green, handing off
+   to `github-pr-fixer`."
+6. Invoke the `github-pr-fixer` skill with the PR number. It takes
+   ownership from here: waiting for CI checks, responding to reviewer
+   comments, and driving the PR to merge.
+7. After merge, `github-pr-fixer` will report back. Re-run the alert
+   inventory query to confirm the GitHub security tab is actually green.
 
 ## Guardrails
 

--- a/.claude/skills/dependabot/SKILL.md
+++ b/.claude/skills/dependabot/SKILL.md
@@ -152,6 +152,21 @@ The `loop` skill will fire the polling command every 5 minutes, including
 the first cycle immediately after the PR is opened. The skill is now
 hands-free — the console can be closed.
 
+### Every poll runs in a laconic subagent
+
+Each 5-minute poll cycle must run inside a subagent (Agent tool,
+`general-purpose`). The parent context does not ingest `gh api` output —
+the subagent returns one line:
+
+- `nothing to do` — literally that string and nothing else
+- `action: <one-line summary>` + new watermark, when a reviewer/Copilot
+  comment requires work
+- `merged` / `closed` when the PR reaches a terminal state
+
+Pass the parent's last comment-id watermark into the subagent; it returns
+the new watermark. This keeps bot noise (SonarCloud badges, self-echoes,
+Dependabot unrelated activity) out of the parent.
+
 ### What each poll cycle does
 
 ```bash

--- a/.claude/skills/gh-cli-guide/SKILL.md
+++ b/.claude/skills/gh-cli-guide/SKILL.md
@@ -173,6 +173,39 @@ gh api "repos/<owner>/<repo>/check-runs/$CHECK_RUN_ID/annotations"
 
 Quote endpoints that contain `?` when running under `zsh`.
 
+## Dependabot & security alerts
+
+The Dependabot security tab (`/security/dependabot`) is backed by the
+`/dependabot/alerts` REST endpoint. Use it instead of scraping the UI.
+
+```bash
+# List every open alert with the minimum fields needed for triage
+gh api repos/<owner>/<repo>/dependabot/alerts --paginate \
+  --jq '.[] | select(.state=="open") | {number, severity: .security_advisory.severity,
+         package: .dependency.package.name, manifest: .dependency.manifest_path,
+         scope: .dependency.scope, summary: .security_advisory.summary,
+         url: .html_url}'
+
+# Full advisory (CVSS, vulnerable range, first-patched version) for one alert
+gh api repos/<owner>/<repo>/dependabot/alerts/<N>
+
+# Dismiss an alert with a reason (see dismissed_reason values below)
+gh api -X PATCH repos/<owner>/<repo>/dependabot/alerts/<N> \
+  -f state=dismissed \
+  -f dismissed_reason=tolerable_risk \
+  -f dismissed_comment='Short justification the security tab will display.'
+
+# PRs that Dependabot itself opened
+gh pr list --state open --json number,title,author,statusCheckRollup \
+  --jq '.[] | select(.author.login=="app/dependabot")'
+```
+
+`dependency.scope` distinguishes `runtime` from `development`. `dismissed_reason`
+must be one of: `fix_started`, `inaccurate`, `no_bandwidth`, `not_used`,
+`tolerable_risk`. For the full fix workflow (triage → bump / override /
+dismiss → validate) see
+[.claude/skills/dependabot/SKILL.md](../dependabot/SKILL.md).
+
 ## Labels
 
 ```bash

--- a/.claude/skills/github-pr-fixer/SKILL.md
+++ b/.claude/skills/github-pr-fixer/SKILL.md
@@ -155,10 +155,34 @@ the line-level comments themselves and the `gstack:status` audit
 comment. Post the resolution summary **after** the inline replies so
 the thread reads in order.
 
+## Waiting for CI — block with `gh pr checks --watch`, don't poll
+
+While CI is still running (standard `validate`, `build-docker`, `CodeQL`,
+`SonarCloud`, etc.), **do not** set up the 5-minute poll. `gh` already has
+the right tool for this: it blocks until every check completes and streams
+updates as it goes.
+
+```bash
+gh pr checks <N> --watch --fail-fast
+```
+
+That call returns only when every check has a terminal state. Use it
+immediately after pushing a round and before arming the poll — one
+blocking syscall is cheaper and faster than 5-minute heartbeats into a
+pending CI run.
+
+Once the call returns:
+
+- If the exit code is non-zero: CI failed. Jump to
+  `references/check-diagnosis.md` without waiting.
+- If the exit code is zero: CI is green. Now switch to the 5-minute poll
+  below for reviewer / closure feedback.
+
 ## Active polling — do not go idle while the PR is open
 
-The skill is not done when checks go green. While the PR is open, the skill
-owns it. Stay active and poll every **5 minutes** for:
+After CI has finished (the `--watch` call returned), the skill is not done.
+While the PR is open, the skill owns it. Stay active and poll every
+**5 minutes** for:
 
 - new PR comments (including reviewer comments, bot comments, and new
   check-run results)

--- a/.claude/skills/github-pr-fixer/SKILL.md
+++ b/.claude/skills/github-pr-fixer/SKILL.md
@@ -178,7 +178,32 @@ Once the call returns:
 - If the exit code is zero: CI is green. Now switch to the 5-minute poll
   below for reviewer / closure feedback.
 
-## Active polling — do not go idle while the PR is open
+## Active polling — delegate every poll to a laconic subagent
+
+**Every 5-minute poll cycle must run inside a subagent** (Agent tool,
+typically `subagent_type: "general-purpose"`). The parent context stays
+lean — subagent output is a single line returned to the parent, not the
+full `gh api` dump.
+
+Brief the subagent with:
+- the PR number and repo
+- the last comment-id / review-id watermark the parent has seen
+- the list of trigger phrases the author can post (`merge it`, `land it`,
+  `release as X.Y.Z`, `close this`)
+
+Demand a **laconic** return contract: one line.
+
+| Subagent finds | Subagent returns |
+|----------------|------------------|
+| No new comments, no state change | `nothing to do` — literally that string, nothing else |
+| New reviewer/Copilot comment requiring action | `action: <one-line summary>` + new watermark |
+| Failing check detected | `fail: <check-name>` + link |
+| Explicit closure phrase from the author | `close: <phrase> by <user>` |
+| PR merged or closed externally | `merged` or `closed` |
+
+The parent only wakes to do work when the subagent returns something
+other than `nothing to do`. This keeps the parent's context from filling
+with bot comments, Quality-Gate badges, and self-echoes.
 
 After CI has finished (the `--watch` call returned), the skill is not done.
 While the PR is open, the skill owns it. Stay active and poll every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ They live in `.claude/skills/` as the single source of truth.
 | `meta` | Capture reusable learnings | [.claude/skills/meta/SKILL.md](.claude/skills/meta/SKILL.md) |
 | `sonar` | Fetch SonarCloud issues and split them by severity | [.claude/skills/sonar/SKILL.md](.claude/skills/sonar/SKILL.md) |
 | `github-pr-fixer` | Watch the current PR, fix failing checks, and loop push/recheck up to three rounds | [.claude/skills/github-pr-fixer/SKILL.md](.claude/skills/github-pr-fixer/SKILL.md) |
+| `dependabot` | Triage and fix Dependabot security alerts via `gh` + `npm` | [.claude/skills/dependabot/SKILL.md](.claude/skills/dependabot/SKILL.md) |
 
 ## Tool-Specific Bootstrap Files
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,14 +1794,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4331,6 +4332,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -4986,24 +4997,24 @@
       }
     },
     "node_modules/telegram-test-api/node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
@@ -5040,16 +5051,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/telegram-test-api/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/telegram-test-api/node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -5075,57 +5076,51 @@
         }
       }
     },
-    "node_modules/telegram-test-api/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/telegram-test-api/node_modules/express": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.3.tgz",
-      "integrity": "sha512-6VyCijWQ+9O7WuVMTRBTl+cjNNIzD5cY5mQ1WM8r/LEkI2u8EYpOotESNwzNlyCn3g+dmjKYI6BmNneSr/FSRw==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/telegram-test-api/node_modules/express/node_modules/debug": {
@@ -5146,18 +5141,18 @@
       "license": "MIT"
     },
     "node_modules/telegram-test-api/node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.2",
         "unpipe": "~1.0.0"
       },
       "engines": {
@@ -5191,23 +5186,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/telegram-test-api/node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/telegram-test-api/node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5232,11 +5210,14 @@
       }
     },
     "node_modules/telegram-test-api/node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/telegram-test-api/node_modules/mime": {
       "version": "1.6.0",
@@ -5285,64 +5266,48 @@
       }
     },
     "node_modules/telegram-test-api/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/telegram-test-api/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/telegram-test-api/node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/telegram-test-api/node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "statuses": "~2.0.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -5366,29 +5331,19 @@
       "license": "MIT"
     },
     "node_modules/telegram-test-api/node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "~0.19.1"
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/telegram-test-api/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/telegram-test-api/node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,17 @@
     "pino": "^10.3.1",
     "telegraf": "^4.16.3"
   },
+  "overrides": {
+    "telegram-test-api": {
+      "axios": "^1.14.0",
+      "body-parser": "^1.20.3",
+      "cookie": "^0.7.0",
+      "express": "^4.21.2",
+      "qs": "^6.14.2",
+      "send": "^0.19.0",
+      "serve-static": "^1.16.0"
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@types/better-sqlite3": "^7.6.13",


### PR DESCRIPTION
## Summary

Introduces the `dependabot` triage skill and, as the worked example, closes
12 of the 13 open Dependabot alerts on `master`. The 13th (#19,
follow-redirects) was closed by Dependabot PR #15, merged separately.

## Resolution table

| Alert # | Pkg | Fix |
|---------|-----|-----|
| 1, 10, 18, 20 | axios | `overrides` → `^1.14.0` (major bump, tests green) |
| 4 | body-parser | `overrides` → `^1.20.3` |
| 5, 2 | express | `overrides` → `^4.21.2` |
| 6 | serve-static | `overrides` → `^1.16.0` |
| 7 | send | `overrides` → `^0.19.0` |
| 8 | cookie | `overrides` → `^0.7.0` |
| 11, 12 | qs | `overrides` → `^6.14.2` |
| 19 | follow-redirects | merged via Dependabot PR #15 |

All overrides are scoped under the `telegram-test-api` subtree so the
production runtime is untouched. The axios 0.27 → 1.x major bump worked
without breaking the e2e Telegram test harness, so nothing had to be
dismissed.

## Skill

Adds `.claude/skills/dependabot/SKILL.md` — a zero-console-interaction
triage workflow: open a draft PR, post the plan in the body, self-invoke
`/loop 5m`, and route every question through PR comments. Also extends
`gh-cli-guide` with the Dependabot/security-alerts endpoints and registers
the skill in `AGENTS.md`.

## Validation

- `npm audit` — 0 vulnerabilities (was 12)
- `npm run lint` — clean
- `npm run test` — 26 files, 270 tests, all green
- `npm run build` — clean
- Open Dependabot alerts on `master` go from 13 → 0 once this PR merges

## Test plan

- [x] Local lint / test / build pass
- [ ] CI checks pass (handed off to `github-pr-fixer` to babysit)
- [ ] Security tab confirmed empty after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)