### PR TITLE
docs(skills): bake polling-discipline memories into the skills

### DIFF
--- a/.claude/skills/gh-security-and-quality/SKILL.md
+++ b/.claude/skills/gh-security-and-quality/SKILL.md
@@ -182,13 +182,33 @@ Every 5-minute fire delegates to a subagent (Agent tool,
 |----------------|------------------|
 | No new activity | `nothing to do` — literally that string, nothing else |
 | Scope selected | `scope: <selection>` |
-| Actionable reviewer / Copilot comment | `action: <summary> (watermark=<new_id>)` |
+| Any copilot/bot comment (including confirmations) | `action: <summary> (watermark=<new_id>)` |
+| Other reviewer comment requiring action | `action: <summary> (watermark=<new_id>)` |
 | Failing check | `fail: <check-name>` |
-| Closure / merge instruction | `close: <phrase> by <user>` or `tag-ok: <tag>` |
+| Closure / merge instruction from the author | `close: <phrase> by <user>` or `tag-ok: <tag>` |
 | PR merged or closed externally | `merged` or `closed` |
 
 Pass the parent's last comment-id watermark into the subagent; it returns
 the new watermark. The parent only wakes to do real work.
+
+**Subagent brief — mandatory contents:**
+
+- the PR number and repo
+- the current watermark
+- **the gh-auth login** (treated as a self-echo) plus the rule:
+  *"comments by `<login>` are the session's own echoes — IGNORE unless
+  they contain a trigger phrase (`scope: `, `tag `, `merge it`,
+  `land it`, `close this`, `release as`)"*
+- **bot-never-filter rule:** *"any author containing `copilot` or
+  `bot` is ALWAYS surfaced as `action:` regardless of tone —
+  Copilot confirmations mean the parent must resolve the threads
+  via the GraphQL `resolveReviewThread` mutation"*
+
+**Watermark discipline:** advance the watermark past every comment the
+parent posts **immediately after posting**, so the next cron fire
+doesn't see its own echo even if the self-filter misses a trigger
+phrase. When the gh auth user and the repo owner are the same person,
+this discipline is the only way to distinguish intent.
 
 ## Step 4: Apply fixes for the chosen scope
 
@@ -279,7 +299,10 @@ tab.
 ## Step 5: Validate, ship, hand off
 
 1. Run `npm audit`, `npm run lint`, `npm run test`, `npm run build` (or
-   the equivalent for the language).
+   the equivalent for the language). Do **not** use the 5-minute poll
+   to wait on CI after the push — `github-pr-fixer` will block with
+   `gh pr checks <N> --watch --fail-fast`, which returns only when
+   every check reaches a terminal state.
 2. Re-query the surfaces in scope and confirm the open-alert count dropped
    as expected.
 3. Update the PR body with the final resolution table (`alert # → fix

--- a/.claude/skills/github-pr-fixer/SKILL.md
+++ b/.claude/skills/github-pr-fixer/SKILL.md
@@ -189,21 +189,52 @@ Brief the subagent with:
 - the PR number and repo
 - the last comment-id / review-id watermark the parent has seen
 - the list of trigger phrases the author can post (`merge it`, `land it`,
-  `release as X.Y.Z`, `close this`)
+  `release as X.Y.Z`, `close this`, `scope: ...`, `tag X.Y.Z`)
+- **the gh-auth login to treat as a self-echo** (see below)
+- **the explicit instruction that bot / Copilot authors are ALWAYS
+  surfaced** (see below)
+
+### Self-echo filter: what NOT to resurface
+
+`gh pr comment` posts as the gh-authenticated user, so every status
+update the parent writes is attributed to that login. The subagent has
+no other way to know which comments are self-echoes. Tell it exactly:
+
+> Comments authored by `<gh-auth-login>` are the session's own echoes —
+> IGNORE them unless they explicitly contain a trigger phrase. When
+> the gh auth user and the repo owner are the same person, this
+> self-filter is mandatory.
+
+**Watermark discipline:** advance the watermark past every comment the
+parent posts, **immediately after the push returns a comment id**, so
+the next cycle never sees its own message even if the self-filter
+misses a new trigger phrase.
+
+### Counterpart rule: NEVER filter bot reviewers
+
+A subagent that interprets a Copilot confirmation as "no action needed"
+will silently drop threads that still need explicit
+GraphQL-`resolveReviewThread` resolution. The brief must force the
+opposite: *every* comment authored by a login containing `copilot` or
+`bot` is surfaced as `action:`, regardless of tone. Interpretation
+("confirmation → resolve threads", "new concern → fix round") lives in
+the parent, not the subagent.
 
 Demand a **laconic** return contract: one line.
 
 | Subagent finds | Subagent returns |
 |----------------|------------------|
 | No new comments, no state change | `nothing to do` — literally that string, nothing else |
-| New reviewer/Copilot comment requiring action | `action: <one-line summary>` + new watermark |
+| Any copilot/bot comment (including confirmations) | `action: <one-line summary>` + new watermark |
+| New human reviewer comment requiring action | `action: <one-line summary>` + new watermark |
 | Failing check detected | `fail: <check-name>` + link |
-| Explicit closure phrase from the author | `close: <phrase> by <user>` |
+| Explicit closure / tag / scope phrase from the author | `close: <phrase> by <user>` / `tag-ok: <version>` / `scope: <selection>` |
 | PR merged or closed externally | `merged` or `closed` |
 
 The parent only wakes to do work when the subagent returns something
-other than `nothing to do`. This keeps the parent's context from filling
-with bot comments, Quality-Gate badges, and self-echoes.
+other than `nothing to do`. This keeps the parent's context from
+filling with bot badges, self-echoes, and SonarCloud Quality-Gate
+decorations.
 
 After CI has finished (the `--watch` call returned), the skill is not done.
 While the PR is open, the skill owns it. Stay active and poll every


### PR DESCRIPTION
## Summary

Fold four cross-session rules from my private memory into the repository skills, so any contributor (on any machine, any Claude session) gets them automatically instead of relying on a single agent's local \`~/.claude\` state.

## Rules baked in

1. **Subagent brief must include the gh-auth login** — comments by that login are session echoes; ignore them unless they contain a trigger phrase.
2. **Subagent brief must NEVER filter bot / Copilot comments** — always surface as \`action:\`, even natural-language confirmations. Interpretation (confirmation → resolve threads via GraphQL) lives in the parent.
3. **Watermark discipline** — advance past every parent-posted comment immediately after posting, so the self-filter never has to decide on an echo.
4. **\`gh pr checks --watch\` blocks on CI** — do not use the 5-minute poll for checks.

Both rules 1 and 2 are corrections from the \`gh-security-and-quality\` session: I missed the author's \`tag-ok\` because the subagent dropped my own echo AS WELL as Copilot's confirmation.

## Files touched

- \`.claude/skills/github-pr-fixer/SKILL.md\` — expanded \"Active polling\" section with the self-echo filter, bot-never-filter rule, watermark discipline, and updated return-contract table.
- \`.claude/skills/gh-security-and-quality/SKILL.md\` — same in Step 3, plus a \`gh pr checks --watch\` note in Step 5 hand-off.

## Test plan

- [x] \`npm run lint\` clean (docs-only, no source changes)
- [x] \`npm run build\` clean
- [ ] CI green
- [ ] Future sessions picking up these skills follow the new brief without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)