### PR TITLE
docs(#25): pre-1.0 technical checkpoint

### DIFF
--- a/.claude/agents/pr-cycle.md
+++ b/.claude/agents/pr-cycle.md
@@ -34,13 +34,13 @@ gh pr status
 gh pr view --json number,title,headRefName,baseRefName,url 2>/dev/null
 ```
 
-If no PR exists, load the `github-pr-fixer` skill and follow the `references/open-pr.md` workflow to create one.
+If no PR exists, follow the workflow in `.claude/skills/github-pr-fixer/references/open-pr.md` to create one. (Do NOT invoke `/github-pr-fixer`; read the reference doc directly as documentation.)
 
 Capture and carry forward: PR number, head branch, base branch, PR URL.
 
 ### Step 2: Wait for checks and diagnose
 
-Load the `github-pr-fixer` skill and follow `references/check-diagnosis.md`:
+Follow the workflow in `.claude/skills/github-pr-fixer/references/check-diagnosis.md`:
 
 1. Wait for the current check cycle to settle before reading results.
 2. Classify each failure: Sonar path, GitHub Actions job path, or standalone security check path.
@@ -90,9 +90,8 @@ gh api repos/<owner>/<repo>/pulls/<PR_NUMBER>/requested_reviewers \
   --jq '.users[].login, .teams[].slug'
 ```
 
-If any reviewer is listed (e.g., `Copilot`), load the
-`github-pr-fixer` skill and follow
-`references/reviewer-comments.md`:
+If any reviewer is listed (e.g., `Copilot`), follow the workflow in
+`.claude/skills/github-pr-fixer/references/reviewer-comments.md`:
 
 1. Poll until the reviewer leaves `requested_reviewers` AND a review
    appears under `/pulls/<N>/reviews` (or until a reasonable timeout).
@@ -107,7 +106,7 @@ comments unless the user explicitly authorises it.
 
 ### Step 5: Merge and release
 
-Load the `github-pr-fixer` skill and follow `references/release-closure.md`:
+Follow the workflow in `.claude/skills/github-pr-fixer/references/release-closure.md`:
 
 1. Determine the release tag from the branch name or latest existing tag.
 2. Ask the user to confirm the tag before proceeding.
@@ -175,9 +174,15 @@ When stopping (success or failure), report:
 - The exact blocking check names and URLs (if blocked)
 - The release tag (if merged)
 
-## Skills Used
+## Reference Docs Used
 
-| Skill | When | Reference docs |
-|-------|------|----------------|
-| `github-pr-fixer` | Open PR, diagnose checks, fix loop, handle reviewer comments, merge | `references/open-pr.md`, `references/pr-resolution.md`, `references/check-diagnosis.md`, `references/fix-loop.md`, `references/reviewer-comments.md`, `references/release-closure.md` |
-| `sonar` | Verify/fix SonarCloud issues | `SKILL.md`, `references/fix-workflow.md` |
+This agent reads reference documents directly — it does NOT invoke the
+`github-pr-fixer` skill. That skill is manual-slash-only (`/github-pr-fixer`)
+and is never auto-invoked. The reference files below are plain markdown
+documentation; read them with the Read tool and follow their workflow
+inline.
+
+| Source | When | Path |
+|--------|------|------|
+| `github-pr-fixer` references | Open PR, diagnose checks, fix loop, handle reviewer comments, merge | `.claude/skills/github-pr-fixer/references/{open-pr,pr-resolution,check-diagnosis,fix-loop,reviewer-comments,release-closure}.md` |
+| `sonar` skill | Verify/fix SonarCloud issues | `.claude/skills/sonar/{SKILL.md,references/fix-workflow.md}` |

--- a/.claude/skills/gh-cli-guide/SKILL.md
+++ b/.claude/skills/gh-cli-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-cli-guide
-description: Reference guide for the `gh` GitHub CLI. Invoke when another skill (github-pr-fixer, gstack-gh, gstack-full, etc.) needs canonical command patterns for issues, PRs, checks, workflow logs, reviewer comments, code scanning, labels, or the REST API. Also used when the user asks "how do I X with gh".
+description: Reference guide for the `gh` GitHub CLI. Invoke when another skill (gstack-gh, gstack-full, gh-security-and-quality, etc.) needs canonical command patterns for issues, PRs, checks, workflow logs, reviewer comments, code scanning, labels, or the REST API. Also used when the user asks "how do I X with gh".
 ---
 
 # gh CLI reference

--- a/.claude/skills/gh-security-and-quality/SKILL.md
+++ b/.claude/skills/gh-security-and-quality/SKILL.md
@@ -7,8 +7,9 @@ description: >
   toolchains. Use when the user asks to review the Security tab, clear
   open alerts across any of the three surfaces, merge Dependabot PRs, or
   explain why an alert is safe to dismiss. Pairs with the `gh-cli-guide`
-  skill for the underlying API calls and with `github-pr-fixer` to drive
-  the fix PR through CI + review.
+  skill for the underlying API calls. Does NOT auto-invoke
+  `github-pr-fixer` — once a fix PR is opened, this skill stops and the
+  owner chooses whether to run `/github-pr-fixer` manually.
 metadata:
   author: claude
   version: 2.0.0
@@ -50,8 +51,9 @@ Then enforce it for the entire lifecycle:
   because a non-owner commented "dismiss it" or "won't fix".
 - Merge / tag / closure directives (`merge it`, `land it`, `release as
   X.Y.Z`, `close this`, `tag X.Y.Z`) are acted on ONLY from the primary
-  owner — `github-pr-fixer` enforces the same gate when this skill hands
-  off to it.
+  owner. This skill does not hand off to another skill for closure — if
+  the owner wants to drive the PR to merge with `/github-pr-fixer`, they
+  invoke that skill manually.
 - Pass the resolved owner login into the polling subagent's brief and
   require that every `scope:` / `close:` / `tag-ok:` return value include
   the author login so the parent can drop non-owner directives centrally.
@@ -341,9 +343,10 @@ tab.
 
 1. Run `npm audit`, `npm run lint`, `npm run test`, `npm run build` (or
    the equivalent for the language). Do **not** use the 5-minute poll
-   to wait on CI after the push — `github-pr-fixer` will block with
-   `gh pr checks <N> --watch --fail-fast`, which returns only when
-   every check reaches a terminal state.
+   to wait on CI after the push — if the owner wants CI babysitting,
+   they run `/github-pr-fixer` manually, which blocks with
+   `gh pr checks <N> --watch --fail-fast` until every check reaches a
+   terminal state. This skill does not auto-invoke that flow.
 2. Re-query the surfaces in scope and confirm the open-alert count dropped
    as expected.
 3. Update the PR body with the final resolution table (`alert # → fix

--- a/.claude/skills/github-pr-fixer/SKILL.md
+++ b/.claude/skills/github-pr-fixer/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: github-pr-fixer
 description: >
-  Fix the current GitHub pull request until checks pass or five fix rounds are
-  exhausted. Use when an open PR has failing or pending checks and you need to
-  inspect GitHub checks with gh, remediate SonarCloud issues with the sonar
-  skill, inspect failed workflow jobs or code scanning alerts, push fixes, and
-  repeat. Also covers: opening a PR from the current branch, waiting for a
-  reviewer (human or Copilot) and addressing their line-level comments, and
-  closing a ready release PR. While the PR is open, stay active and poll PR
-  comments every five minutes for new feedback or an explicit closure
-  instruction — do not go idle.
+  MANUAL SLASH-ONLY skill. Invoke EXCLUSIVELY when the user types
+  `/github-pr-fixer`. Never auto-invoke, never chain from another skill, never
+  treat any other skill's handoff comment or instruction as a trigger. When
+  the user runs it directly: fix the current GitHub pull request until checks
+  pass or five fix rounds are exhausted — inspect GitHub checks with gh,
+  remediate SonarCloud issues with the sonar skill, inspect failed workflow
+  jobs or code scanning alerts, push fixes, repeat. Also covers (on direct
+  user request): opening a PR from the current branch, waiting for a reviewer
+  (human or Copilot) and addressing their line-level comments, and closing a
+  ready release PR. While invoked, stay active and poll PR comments every
+  five minutes for new feedback or an explicit closure instruction — do not
+  go idle.
+disable-model-invocation: true
 metadata:
   author: codex
   version: 1.4.0
@@ -17,6 +21,14 @@ metadata:
 ---
 
 # Skill: GitHub PR Fixer
+
+**Invocation rule (hard):** this skill runs ONLY when the user explicitly
+types `/github-pr-fixer`. It is never auto-invoked, never chained from
+another skill, and never triggered by a handoff comment, label, or PR event.
+If you reach this file because another skill suggested you "invoke
+github-pr-fixer", stop — that other skill is out of date; the correct
+behaviour is to stop and wait for the user to run the slash command
+themselves.
 
 Use this skill to drive a PR to green with `gh` and the existing `sonar`
 skill, or to close a ready release PR when the user explicitly asks for that

--- a/.claude/skills/gstack-full/SKILL.md
+++ b/.claude/skills/gstack-full/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gstack-full
 description: Poll GitHub for open issues carrying a user-specified label and drive each one through gstack's end-to-end flow (plan → build → test → ship) via the `gstack-gh` skill. Use when the user says "watch GH for issues with label X and implement them", "auto-process the backlog", or "poll for ready stories". Supports three scheduling modes — in-session loop, self-paced loop, or cron (remote trigger).
+disable-model-invocation: true
 ---
 
 # gstack-full — label-driven automation loop
@@ -150,8 +151,11 @@ orchestrator level:
 - **All human Q&A goes through `gh issue comment` / `gh pr comment`**, never
   the Claude console. When a question is outstanding, the skill polls the
   issue/PR every `poll-seconds` (default 60) for a reply.
-- **Once the PR is open, `github-pr-fixer` takes over monitoring** (checks,
-  reviewer comments). Do not duplicate that work from this orchestrator.
+- **Once the PR is open, this orchestrator stops touching it.** PR-side
+  work (CI fixing, reviewer comments, closure) is owned by the primary
+  owner, who may — at their discretion — run `/github-pr-fixer` manually.
+  This skill MUST NOT auto-invoke `github-pr-fixer`; that skill is
+  manual-slash-only.
 - **The PR is closed only when the user says so explicitly** — typically as
   a comment on the PR/issue or a chat instruction like "close PR #456" or
   "release as X.Y.Z". `gstack-full` must not close PRs unattended.

--- a/.claude/skills/gstack-gh/SKILL.md
+++ b/.claude/skills/gstack-gh/SKILL.md
@@ -18,11 +18,20 @@ would leave the issue out of the loop.**
 - Repo-specific implementation skills: `new-feature`, `bug-fix`, `small-change`,
   `refactor`, `add-domain` — pick the one that matches the issue's nature.
 
-**Do NOT auto-invoke `github-pr-fixer`.** That skill is manual-slash-only
-(`/github-pr-fixer`) and is never chained from here. Once the PR is open,
-this skill posts a `gstack:handoff` comment and stops. Any downstream
-CI-fix, reviewer-comment, or release-closure work happens only if the
-primary owner explicitly runs `/github-pr-fixer` themselves.
+**This skill owns the PR until it is merged or closed.** After the PR is
+marked ready (step 7), `gstack-gh` continues to:
+
+1. Block on `gh pr checks <pr> --watch --fail-fast` until CI reaches a
+   terminal state.
+2. Poll PR reviewer comments at the ≥ 600 s floor, delegating each cycle
+   to a laconic subagent that ignores its own comments.
+3. Address CI failures and reviewer feedback itself — fix, commit, push,
+   repeat.
+4. Exit only when the PR state is `MERGED` or `CLOSED`, or when the
+   primary owner explicitly tells the skill to stand down.
+
+`github-pr-fixer` is NOT auto-invoked from here — `gstack-gh` handles
+reviewer and CI follow-up directly, in the same continuous session.
 
 ## Inputs (from args)
 
@@ -351,31 +360,59 @@ gh pr ready <pr-number>
   `gstack:handoff`) noting the PR is out of draft and ready for review. The
   issue thread has already been told (in step 4) that communication moved
   to the PR; this final issue comment is just the closing pointer.
-- `gstack-gh` stops here. Any PR-side work (CI fixing, reviewer comments,
-  closure) is owned by the primary owner, who may — at their discretion —
-  run `/github-pr-fixer` manually on the PR. This skill MUST NOT
-  auto-invoke that flow.
+- After the PR is marked ready, `gstack-gh` continues owning the PR through
+  CI and review (steps 8 and 9). `github-pr-fixer` is NOT invoked.
 
-### 8. Stop after hand-off — do NOT auto-invoke downstream skills
+### 8. Watch CI to terminal state
 
-Once the PR is open and the `gstack:handoff` comment is posted:
+Immediately after `gh pr ready`, block on GitHub Actions:
 
-1. Post a final `gstack:status` update on the issue summarising the work
-   (branch, commit, PR URL, validation commands run).
-2. Exit. Do not start polling the PR, do not invoke `github-pr-fixer`,
-   do not loop. The owner chooses whether to run `/github-pr-fixer` (or any
-   other skill) manually.
+```bash
+gh pr checks <pr-number> --watch --fail-fast
+```
 
-### 9. Closing the PR — explicit user action only
+This call blocks until every required check reaches a terminal state. Do
+NOT replace it with a 5-minute polling loop — the `--watch` command is the
+correct primitive for CI (see `feedback_pr_checks_watch` memory).
 
-**The PR is never closed, merged, or land-and-deployed by this skill.**
+- If all checks pass, move to step 9.
+- If any check fails, read the failing workflow logs
+  (`gh run view <run-id> --log-failed`), fix on `feature/<N>`, commit, push,
+  and re-enter `gh pr checks --watch`. Loop until green. Post a
+  `gstack:status` on the PR for each fix iteration summarising the
+  failure and the fix.
 
-- `done-label` is NOT applied at ship time.
-- Release closure is driven by the owner through `/github-pr-fixer` or an
-  equivalent manual action — this skill neither invokes it nor monitors it.
-- If the owner later asks this skill to apply `done-label` and post a final
-  `gstack:status` on the issue after a merge, that's fine — but the merge
-  itself is never done from here.
+### 9. Poll reviewer comments until the PR is merged or closed
+
+Once CI is green, poll for owner feedback on the PR with the ≥ 600 s floor
+(per `feedback_poll_min_interval`), delegating each cycle to a laconic
+subagent that returns `nothing to do` when idle (per
+`feedback_poll_in_laconic_subagent` and `feedback_poll_ignore_self_echo`).
+
+Advance the watermark immediately after any comment `gstack-gh` posts, so
+the subagent never re-reads the session's own output.
+
+For each owner comment that asks for a change or raises a finding:
+
+1. Apply the change on `feature/<N>`, commit with a scope-matched message,
+   push.
+2. Re-enter `gh pr checks --watch` to confirm CI stays green.
+3. Post a `gstack:status` reply on the PR summarising what changed and the
+   commit hash.
+
+Exit conditions:
+
+- PR state becomes `MERGED` — post a final `gstack:status` on the **issue**
+  noting the merge commit, apply `done-label`, remove `claim-label`, exit.
+- PR state becomes `CLOSED` without merge — post a `gstack:status` on the
+  issue noting the close, remove `claim-label`, apply `fail-label` if the
+  close was not owner-directed, exit.
+- Owner explicitly tells `gstack-gh` to stand down (comment: "stand down",
+  "stop polling", or equivalent, owner-filtered) — post an acknowledgement
+  and exit without applying `done-label`.
+
+Do NOT auto-merge. Merging is the owner's decision; wait for them to click
+merge (or to post an owner-authored directive asking this skill to merge).
 
 ## Failure handling
 
@@ -395,7 +432,9 @@ If any step fails and cannot be recovered automatically:
 ## What this skill does NOT do
 
 - Does not ask the user anything through the console — issue/PR comments only.
-- Does not merge or close PRs. Closure requires explicit user confirmation.
+- Does not auto-merge. The owner clicks merge (or issues an owner-filtered
+  directive asking this skill to merge). `gstack-gh` does apply `done-label`
+  and post the final status once the PR becomes `MERGED`.
 - Does not re-plan architecture decisions without a human reply on the issue.
 - Does not touch `.env` or read secrets.
 - Does not run integration tests against real external services unless the

--- a/.claude/skills/gstack-gh/SKILL.md
+++ b/.claude/skills/gstack-gh/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gstack-gh
 description: Take a single GitHub issue (by number or URL) and drive it through an end-to-end flow (branch → plan → build → test → PR) using the `gh` CLI. All user interaction happens through issue comments, never the console. Use when the user says "implement issue #N", "work this GH issue", "take issue X end-to-end", or passes a GitHub issue link. For label-based polling across many issues, use `gstack-full` instead.
+disable-model-invocation: true
 ---
 
 # gstack-gh — one issue, end-to-end
@@ -14,10 +15,14 @@ would leave the issue out of the loop.**
 
 **Reference skills:**
 - `gh-cli-guide/SKILL.md` — canonical `gh` command patterns for every step below.
-- `github-pr-fixer/SKILL.md` — the downstream skill that monitors the PR once
-  it is open (checks, reviewer comments, release-closure).
 - Repo-specific implementation skills: `new-feature`, `bug-fix`, `small-change`,
   `refactor`, `add-domain` — pick the one that matches the issue's nature.
+
+**Do NOT auto-invoke `github-pr-fixer`.** That skill is manual-slash-only
+(`/github-pr-fixer`) and is never chained from here. Once the PR is open,
+this skill posts a `gstack:handoff` comment and stops. Any downstream
+CI-fix, reviewer-comment, or release-closure work happens only if the
+primary owner explicitly runs `/github-pr-fixer` themselves.
 
 ## Inputs (from args)
 
@@ -85,13 +90,35 @@ Then enforce it for the entire flow:
 Persist the resolved owner login alongside the other run args so every
 polling call and every subagent delegation carries it.
 
-## Communication protocol — everything goes through the issue
+## Communication protocol — everything goes through GitHub
 
-This is a hard rule for this skill and for anything it delegates to:
+**This is a hard rule for this skill and for every skill it delegates to.
+No exceptions, no "just this once".** It binds `gstack-gh` itself and every
+downstream implementation skill (`new-feature`, `bug-fix`, `small-change`,
+`refactor`, `add-domain`) it invokes — those skills inherit this protocol
+for the duration of a gstack run and MUST NOT fall back to the console.
+
+**Channel selection is determined by phase, not by convenience.** There are
+two valid channels — the issue thread and the PR thread — and you switch
+between them at exactly one point in the flow:
+
+| Phase                                         | Channel                  | Why                                                                 |
+| --------------------------------------------- | ------------------------ | ------------------------------------------------------------------- |
+| Fetch, claim, plan, plan-approval wait        | Issue (`gh issue comment`) | No code exists yet; the plan belongs to the issue's discussion.     |
+| From the moment implementation starts onward  | PR (`gh pr comment`)       | Code is being written; the PR is the artefact under discussion.     |
+
+**The transition point is fixed: the PR is opened as a DRAFT the instant
+`gstack-gh` moves from "plan approved" to "writing code" — before the first
+file is edited.** From that moment on, every question, status update,
+decision request, failure report, and hand-off goes on the PR thread, not
+the issue and not the console. The issue thread is closed to new bot
+comments (except the `gstack:handoff` pointer and the final release-
+closure status) — it is a completed record of the planning phase.
+
+**Rules that apply in BOTH phases:**
 
 - **Never** ask the user a question in the chat console. Always post the
-  question as a new comment on the issue (or, after the PR exists, on the
-  PR) and then wait for an answer on the same thread.
+  question on the active channel (issue before draft-PR exists; PR after).
 - Prefix every bot comment with a machine-readable marker so you can
   identify your own messages when polling:
 
@@ -214,7 +241,57 @@ Concrete rules:
   keeps the session responsive to other user input while the wait is in
   flight.
 
-### 4. Build
+### 4. Open the draft PR — BEFORE writing any code
+
+The moment the plan is approved and you're about to start implementation,
+open the PR as a **draft** on the already-pushed `feature/<N>` branch.
+This MUST happen before any file is edited. The purpose is to make the PR
+the communication channel for the rest of the flow — every question,
+status update, decision request, and failure report during implementation
+goes on the PR thread, not the issue, and never the console.
+
+The `feature/<N>` branch already has a remote ref from step 2, so no
+initial commit is needed to open the draft PR (GitHub requires at least
+one commit on the branch; the push in step 2 may have created an empty
+branch — if `gh pr create` complains about no commits, make a single
+empty `chore(#<N>): open draft PR for implementation` commit on the
+branch first, then retry).
+
+```bash
+gh pr create \
+  --draft \
+  --head feature/<N> \
+  --base <base> \
+  --title "<type>(#<N>): <title>" \
+  --body-file <(cat <<'EOF'
+## Summary
+- Implementing #<N> per the approved plan.
+- **Status:** draft — implementation in progress.
+- **Channel:** this PR thread is now the communication channel. Questions,
+  decision requests, and status updates from the agent will appear here.
+
+Closes #<N>
+
+## Plan
+<copy the approved plan comment URL from the issue>
+
+## Test plan
+- [ ] (filled in once implementation is complete)
+EOF
+)
+```
+
+Immediately after the PR is created:
+
+1. Post a `gstack:status` comment on the **issue** (marker:
+   `gstack:handoff-to-pr`) with the PR URL and a one-line note: "Further
+   updates will appear on the PR thread."
+2. From now on, use `gh pr comment <pr-number>` for all questions, status,
+   and decision polling. Apply the same owner-login filter and watermark
+   discipline described in the Communication protocol section, against
+   `gh pr view --json comments` instead of `gh issue view --json comments`.
+
+### 5. Build
 
 Implement on `feature/<N>`. Pick the matching repo skill if one applies:
 
@@ -224,11 +301,14 @@ Implement on `feature/<N>`. Pick the matching repo skill if one applies:
 - `refactor` for behavior-preserving restructure
 - `add-domain` for a new bounded context
 
-If the implementation hits a decision you cannot make alone (ambiguous
-acceptance criteria, a forced trade-off), **stop and ask via an issue
-comment** — do not guess, and do not ask in the console.
+**Every delegated skill inherits the communication protocol.** Brief it
+explicitly in the delegation: "all user communication goes on PR #<N> via
+`gh pr comment`; never use the console." If the implementation hits a
+decision the agent cannot make alone (ambiguous acceptance criteria, a
+forced trade-off), **stop and ask via a PR comment** — do not guess, and
+do not ask in the console.
 
-### 5. Test
+### 6. Test
 
 Discover the repo's validation commands (`package.json` scripts, `Makefile`,
 `*.sln`, CLAUDE.md / AGENTS.md) and run them locally. Common patterns:
@@ -237,72 +317,79 @@ Discover the repo's validation commands (`package.json` scripts, `Makefile`,
 - Python: `pytest` / `ruff check` / etc.
 - .NET: `dotnet test` for each target framework configured in the solution
 
-If tests fail, fix them before shipping. Do not mark the issue done with red
-tests. Integration or external-API tests run only if the user explicitly
-asked in the issue.
+If tests fail, fix them before marking the PR ready. Do not mark the issue
+done with red tests. Integration or external-API tests run only if the user
+explicitly asked in the issue. Post a `gstack:status` comment on the PR
+summarising which commands were run and their result.
 
-### 6. Ship (open the PR)
+### 7. Push and mark the PR ready for review
 
-When the build is green locally, push and open the PR.
+The draft PR was opened in step 4, so the PR already exists. Push the
+implementation commits to the already-tracked `feature/<N>` branch, update
+the PR body's "Test plan" section to list the validation commands that
+actually ran, and flip the PR out of draft state.
 
 ```bash
-git push                          # feature/<N> already tracked from step 2
-gh pr create \
-  --head feature/<N> \
-  --base <base> \
-  --title "<type>(#<N>): <title>" \
-  --body-file <(cat <<'EOF'
+git push
+gh pr edit <pr-number> --body-file <(cat <<'EOF'
 ## Summary
 - <what/why, 1-3 bullets>
 
 Closes #<N>
 
 ## Test plan
-- [ ] <validation commands that were run>
+- [x] <validation commands that actually ran>
 EOF
 )
+gh pr ready <pr-number>
 ```
 
-- Title: `fix(#<N>): ...` for bug-fix, `feat(#<N>): ...` for new-feature,
-  `chore(#<N>): ...` / `refactor(#<N>): ...` etc. as appropriate.
-- Body MUST contain `Closes #<N>` — this is the binding that links the PR to
-  the issue and auto-closes it on merge.
-- Also call `gh issue comment <N> --body "PR: <pr-url>"` (marker:
-  `gstack:handoff`) so the issue thread contains an explicit pointer.
-- `github-pr-fixer` takes over from here to monitor checks and reviews.
+- Title was set in step 4; adjust via `gh pr edit --title` only if the
+  implementation changed the nature of the change (e.g. `chore` → `fix`).
+- Body MUST still contain `Closes #<N>`.
+- Post a `gstack:handoff` comment on the **issue** (marker:
+  `gstack:handoff`) noting the PR is out of draft and ready for review. The
+  issue thread has already been told (in step 4) that communication moved
+  to the PR; this final issue comment is just the closing pointer.
+- `gstack-gh` stops here. Any PR-side work (CI fixing, reviewer comments,
+  closure) is owned by the primary owner, who may — at their discretion —
+  run `/github-pr-fixer` manually on the PR. This skill MUST NOT
+  auto-invoke that flow.
 
-### 7. Hand off to `github-pr-fixer`
+### 8. Stop after hand-off — do NOT auto-invoke downstream skills
 
-Once the PR is open:
+Once the PR is open and the `gstack:handoff` comment is posted:
 
-1. Post a `gstack:handoff` comment on the issue with the PR URL.
-2. Invoke `github-pr-fixer` on the newly-created PR. From this point, any
-   further automated work (CI fix rounds, reviewer comments, release
-   closure) is owned by that skill — but it inherits the same rule: any
-   human question goes through `gh pr comment` on the PR (or the linked
-   issue), never through the console, and it polls the same way.
+1. Post a final `gstack:status` update on the issue summarising the work
+   (branch, commit, PR URL, validation commands run).
+2. Exit. Do not start polling the PR, do not invoke `github-pr-fixer`,
+   do not loop. The owner chooses whether to run `/github-pr-fixer` (or any
+   other skill) manually.
 
-### 8. Closing the PR — explicit user confirmation only
+### 9. Closing the PR — explicit user action only
 
-**The PR is never closed, merged, or land-and-deployed automatically.**
+**The PR is never closed, merged, or land-and-deployed by this skill.**
 
 - `done-label` is NOT applied at ship time.
-- `github-pr-fixer`'s release-closure path runs only when the user issues an
-  explicit instruction (in chat, or as a comment on the PR / issue containing
-  a phrase like "close this PR", "land it", "release as X.Y.Z").
-- When that confirmation arrives, follow
-  `github-pr-fixer/references/release-closure.md`, then apply `done-label`
-  to the issue and post a final `gstack:status` comment on the issue
-  summarising what shipped.
+- Release closure is driven by the owner through `/github-pr-fixer` or an
+  equivalent manual action — this skill neither invokes it nor monitors it.
+- If the owner later asks this skill to apply `done-label` and post a final
+  `gstack:status` on the issue after a merge, that's fine — but the merge
+  itself is never done from here.
 
 ## Failure handling
 
 If any step fails and cannot be recovered automatically:
 
 1. Remove `claim-label`, add `fail-label`.
-2. Post a `gstack:failure` comment on the issue with: what failed, what was
-   tried, any log excerpts, and what is needed from a human.
-3. Leave `feature/<N>` intact (local and remote) so the user can inspect.
+2. Post a `gstack:failure` comment with: what failed, what was tried, any
+   log excerpts, and what is needed from a human. **Channel follows the
+   phase rule:** post on the ISSUE if the draft PR has not been opened yet
+   (failure during steps 1–3), or on the PR if the draft PR already exists
+   (failure during steps 4–7). Cross-link: if the failure is on the PR,
+   also post a one-line `gstack:status` on the issue pointing to the PR
+   comment, so the issue's linear record stays complete.
+3. Leave `feature/<N>` and the draft PR intact so the user can inspect.
 4. Exit. Do not pretend success.
 
 ## What this skill does NOT do

--- a/.claude/skills/gstack-gh/SKILL.md
+++ b/.claude/skills/gstack-gh/SKILL.md
@@ -23,7 +23,7 @@ marked ready (step 7), `gstack-gh` continues to:
 
 1. Block on `gh pr checks <pr> --watch --fail-fast` until CI reaches a
    terminal state.
-2. Poll PR reviewer comments at the ≥ 600 s floor, delegating each cycle
+2. Poll PR reviewer comments every 5 minutes (300 s), delegating each cycle
    to a laconic subagent that ignores its own comments.
 3. Address CI failures and reviewer feedback itself — fix, commit, push,
    repeat.
@@ -384,8 +384,8 @@ correct primitive for CI (see `feedback_pr_checks_watch` memory).
 
 ### 9. Poll reviewer comments until the PR is merged or closed
 
-Once CI is green, poll for owner feedback on the PR with the ≥ 600 s floor
-(per `feedback_poll_min_interval`), delegating each cycle to a laconic
+Once CI is green, poll for owner feedback on the PR every 5 minutes
+(300 s cadence), delegating each cycle to a laconic
 subagent that returns `nothing to do` when idle (per
 `feedback_poll_in_laconic_subagent` and `feedback_poll_ignore_self_echo`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ They live in `.claude/skills/` as the single source of truth.
 | `doc-gardening` | Keep documentation accurate | [.claude/skills/doc-gardening/SKILL.md](.claude/skills/doc-gardening/SKILL.md) |
 | `meta` | Capture reusable learnings | [.claude/skills/meta/SKILL.md](.claude/skills/meta/SKILL.md) |
 | `sonar` | Fetch SonarCloud issues and split them by severity | [.claude/skills/sonar/SKILL.md](.claude/skills/sonar/SKILL.md) |
-| `github-pr-fixer` | Watch the current PR, fix failing checks, and loop push/recheck up to three rounds | [.claude/skills/github-pr-fixer/SKILL.md](.claude/skills/github-pr-fixer/SKILL.md) |
+| `github-pr-fixer` | **Manual slash-only** (`/github-pr-fixer`). Never auto-invoked or chained from another skill. Watches the current PR, fixes failing checks, and loops push/recheck up to five rounds | [.claude/skills/github-pr-fixer/SKILL.md](.claude/skills/github-pr-fixer/SKILL.md) |
 | `gh-security-and-quality` | Triage and fix GitHub security and quality findings (Dependabot, code-scanning, secret / malware) via `gh` + `npm` | [.claude/skills/gh-security-and-quality/SKILL.md](.claude/skills/gh-security-and-quality/SKILL.md) |
 
 ## Tool-Specific Bootstrap Files

--- a/docs/quality/PRE-1.0-CHECKPOINT.md
+++ b/docs/quality/PRE-1.0-CHECKPOINT.md
@@ -366,34 +366,35 @@ Commit-type hygiene per CODE-STANDARDS §Commit Messages is solid.
 | Docs coverage (JSDoc) | ⚠️ security symbols undocumented (S2) |  |
 | Operational limits documented | ⚠️ in-memory pending store not in README (R3) |  |
 
-### 9.1 Must-fix before 1.0 (P0)
+### 9.1 Tracked in GitHub issues
 
-1. **A1 + D1 — doc drift from #21.** Add `request-proxy` to
-   `DOMAIN-BOUNDARIES.md` (registry, boundary map, integration contracts) and a
-   row to `QUALITY-GRADES.md`.
-2. **R2 — CHANGELOG.** At minimum, generate a 1.0 CHANGELOG from `git log` that
-   lists every tagged release from 0.1.0 through 0.8.1 and the 1.0 summary.
-3. **C1 — `registerExecuteRoutes` decomposition.** 289 lines with `cc=21` is a
-   future-regression magnet. Split as described in §6.1.
+Every P0 and P1 finding from this checkpoint has been promoted to its own
+tracking issue. Work and discussion happens there — this report no longer
+restates them.
+
+**Must-fix before 1.0 (P0):**
+
+- #28 — A1 + D1: add `request-proxy` to `DOMAIN-BOUNDARIES.md` and
+  `QUALITY-GRADES.md`
+- #29 — R2: add `CHANGELOG.md`
+- #30 — C1: decompose `registerExecuteRoutes`
+
+**Should-fix before 1.0 (P1):**
+
+- #31 — C2: decompose `authorizeProxyRequest` into a typed decision chain
+- #32 — C3: flatten `executeCommand` nesting
+- #33 — C4: hoist optional-collaborator branches out of `createApp`
+- #34 — C5: split `cli.ts` and `register_execute_routes.ts`
+- #35 — S2: JSDoc on the API-key-store surface
+- #36 — S3: audit `command-gateway` for redundant rate limiting
+- #37 — R3: README section on operational limits
 
 > R1 (package.json version drift) was investigated and dropped: the
 > publish pipeline overwrites the field at publish time
 > (`.github/workflows/ci.yml:137`), so the committed placeholder is
 > intentional. See §8.4.
 
-### 9.2 Should-fix before 1.0 (P1)
-
-5. **C2** — decompose `authorizeProxyRequest` into a typed decision chain.
-6. **C3** — flatten `executeCommand` from `max_nesting=6` to ≤3.
-7. **C4** — pull optional-collaborator branches out of `createApp`.
-8. **C5** — split `cli.ts` (per-subcommand) and `register_execute_routes.ts`
-   (per the C1 split).
-9. **S2** — add JSDoc to the API-key-store public surface.
-10. **S3** — audit `command-gateway` request path for redundant rate limiting.
-11. **R3** — README section on operational limits (single-process state,
-    SQLite-only).
-
-### 9.3 Nice-to-have / post-1.0 (P2)
+### 9.2 Nice-to-have / post-1.0 (P2)
 
 12. **S1** — shared boundary-validation helper.
 13. **T1** — dedicated tests for `stats` / `log` CLI commands.

--- a/docs/quality/PRE-1.0-CHECKPOINT.md
+++ b/docs/quality/PRE-1.0-CHECKPOINT.md
@@ -1,0 +1,448 @@
+# Pre-1.0 Technical Checkpoint
+
+> **Scope:** end-to-end architecture, design, testing, code quality, operational &
+> security posture, docs, and 1.0 release readiness.
+> **Branch:** `feature/25` (Closes #25)
+> **Date:** 2026-04-19
+> **Method:** `/plan-eng-review` framing applied to the existing code (no plan file).
+> Structural claims backed by the `tokensave` code graph
+> (1025 nodes, 1632 edges, 108 files, 247 functions, 64 methods); runtime claims
+> backed by `npm test` (323 tests / 29 files — all passing), `npm run lint` (clean),
+> `npm run check:structure` (clean). Index contained 26 stale files at capture
+> time; this only affects *a few* `dist/` entries in graph output, which are ignored
+> below.
+> **Deliverable rule:** this report is the artefact. No code changes were folded in.
+> Every recommendation is an explicit candidate for a follow-up issue.
+
+---
+
+## 1. Executive verdict
+
+**Ship 1.0 after closing the four Must-fix items listed in §9.** Structurally the
+codebase is in good shape: zero circular dependencies, zero recursion cycles, zero
+dead code, zero unused imports, zero `TODO`/`FIXME`/`@ts-expect-error` markers, and
+a mechanically-enforced layered dependency direction (`Types → Config → Repository
+→ Service → Runtime → UI/API`). The gaps that block a confident 1.0 cut are
+*release-hygiene* gaps (version/changelog discipline) and a small number of
+*complexity hotspots* in the newer HTTP-boundary code.
+
+## 2. Repo snapshot
+
+| Metric | Value | Source |
+|---|---|---|
+| Source files (`.ts`, non-test) | 39 | `find server/src -name "*.ts" -not -name "*.test.ts"` |
+| Test files | 29 | `find server/src -name "*.test.ts"` |
+| Tests | 323 passing / 29 files | `npm test` |
+| Functions | 247 | `tokensave_status` |
+| Methods | 64 | `tokensave_status` |
+| Interfaces | 68 | `tokensave_status` |
+| Type aliases | 13 | `tokensave_status` |
+| Circular deps | 0 | `tokensave_circular` |
+| Recursion cycles | 0 | `tokensave_recursion` |
+| Dead-code symbols | 0 | `tokensave_dead_code` |
+| Unused imports | 0 | `tokensave_unused_imports` |
+| God classes | 0 | `tokensave_god_class` |
+| `TODO` / `FIXME` / `HACK` / `@ts-expect-error` in `server/src` | 0 | grep |
+| Lint | clean | `npm run lint` |
+| Structure check | clean | `npm run check:structure` |
+| Semver tags in history | 21 (latest: `0.8.1`) | `git tag --list` |
+| `package.json` version | `0.1.0-alpha.1` | `package.json:3` |
+| `CHANGELOG.md` | absent | `ls` |
+| `VERSION` file | absent | `ls` |
+
+Stack: TypeScript (strict), Node ≥ 22, Express, `better-sqlite3`, `telegraf`, Vitest,
+Pino. Distribution: `dist/server/cli.js` as the `lucifer-gate` bin via `npm`.
+
+## 3. Architecture compliance
+
+### 3.1 Layered dependency direction
+
+The rule in [docs/architecture/DEPENDENCY-RULES.md](../architecture/DEPENDENCY-RULES.md)
+is enforced mechanically by `scripts/check-dependencies.mjs` (wired into
+`npm run build`). `tokensave_circular` reports **0 cycles** and
+`npm run check:structure` passes — the invariant holds today.
+
+### 3.2 Domain boundaries
+
+Three domains live under `server/src/domains/`:
+
+| Domain | Files | Role |
+|---|---|---|
+| `command-gateway` | ~24 | Auth, rules, approvals (Telegram/web/multi/auto), execute, SQLite, audit |
+| `platform-api` | ~5 | `/api/health`, app wiring helpers |
+| `request-proxy` | ~5 | Transparent HTTP proxy with API-key + Telegram approval modes (landed #21) |
+
+**Finding A1 (confidence 10/10):** `docs/architecture/DOMAIN-BOUNDARIES.md` documents
+only `command-gateway` and `platform-api`. The `request-proxy` domain introduced by
+PR #21 (commit `7d04582`) is missing from the domain registry, boundary map, and
+integration-contract table. This is a hard documentation drift: AGENTS rule 6
+requires docs to update in the same change as behaviour.
+
+### 3.3 Composition root
+
+`server/src/create_app.ts:162 createApp()` wires 21 distinct collaborators
+(`tokensave_complexity` fan-out=21). A wiring function *should* be the highest-fan-out
+node in the graph — that part is expected. What's not expected is `max_nesting=5`
+inside a composition root: branching on env vars, config flags, and optional
+collaborators inside the same function is the main cause. See Finding C1.
+
+### 3.4 Coupling fan-in hot spots (healthy)
+
+Top fan-in files are all *type* or *repository* boundary files —
+`store_interfaces.ts` (7), `proxy_types.ts` (6), `api_key_store.ts` (6),
+`command_types.ts` (5). That is the expected shape: shared types and repository
+contracts fan in, business logic doesn't. No god modules.
+
+## 4. Design review
+
+### 4.1 Public HTTP surface
+
+| Domain | Routes | Auth |
+|---|---|---|
+| `command-gateway` | `POST /api/v1/execute`, `GET /admin/approvals`, `GET /api/v1/admin/approvals/pending`, `POST /api/v1/admin/approvals/stream-ticket`, `GET /api/v1/admin/approvals/stream`, `POST /api/v1/admin/approvals/:requestId/decide` | API key (execute), admin bearer (admin) |
+| `platform-api` | `GET /api/health` | none |
+| `request-proxy` | transparent passthrough on a separate port | API key + (optional) Telegram |
+
+All five admin routes live in one file (`register_approval_routes.ts`); execute in
+another. This is consistent with the documented UI-layer rule (UI may only import
+`types` + `service`).
+
+### 4.2 Patterns observed
+
+- **Factory functions + small interfaces** for repositories (`createApiKeyStore`,
+  `createApprovalStore`, `createCommandRulesStore`, `createPendingRequestStore`)
+  and for approval channels (`createAutoApproveChannel`,
+  `createTelegramApprovalChannel`, `createWebApprovalChannel`,
+  `createMultiApprovalChannel`). Good — easy to substitute, easy to test.
+- **Result-like flows at the HTTP boundary** — `authorizeProxyRequest` returns a
+  tagged decision object with 13 return sites; the caller dispatches on the tag.
+  Consistent with the "prefer result-like flows for expected failures" invariant.
+- **Pino child loggers per module** — every subsystem gets a named child logger.
+
+### 4.3 Anti-patterns / smells
+
+- **`authorizeProxyRequest` has 13 return sites** for one flow (175 lines, cc=15,
+  fan_out=15). The shape is "validate ↓ / decide ↓ / emit ↓" collapsed into one
+  function. See Finding C2.
+- **`executeCommand` reaches `max_nesting=6`** — the deepest nesting in the entire
+  codebase. See Finding C3.
+- **In-memory pending-request store** (documented in
+  [QUALITY-GRADES.md:17](./QUALITY-GRADES.md)). A restart drops every in-flight
+  approval. Not a bug; an advertised constraint — but a 1.0 release should state it
+  in the README's operational-limits section. See Finding R1.
+
+## 5. Testing review
+
+### 5.1 Coverage breadth
+
+323 tests across 29 files. Coverage map (inferred from test-file naming):
+
+| Area | Test files | Notes |
+|---|---|---|
+| Command gateway — execute routes | `register_execute_routes.test.ts` (503 lines) | Largest single suite — happy path + 409 dup + risk + alias bypass |
+| Command gateway — approval routes | `register_approval_routes.test.ts` (612 lines) | Admin routes + SSE tickets — the one non-trivial test surface |
+| Command gateway — telegram approval | `request_telegram_approval.test.ts` (391 lines) | Bot integration seams |
+| Command gateway — schema contracts | `schema_contracts.test.ts` (344 lines) | Boundary validation |
+| Command gateway — CLI | `cli.test.ts` (485 lines) | `--init`, `pair`, option parsing |
+| Request-proxy — proxy server | `proxy_server.test.ts` (542 lines) | End-to-end proxy behavior |
+| Request-proxy — proxy auth | `proxy_auth.test.ts` (385 lines) | Auth decision tree |
+| E2E — Telegram | `telegram-e2e.test.ts` (473 lines) | Integration harness |
+
+### 5.2 Gaps identified
+
+**Finding T1 (confidence 8/10):** `stats` and `log` CLI commands ride on integration
+by convention, not dedicated command-level tests (already flagged in
+[QUALITY-GRADES.md:19](./QUALITY-GRADES.md) as a known gap). Worth resolving before
+1.0 — these are the two operator-facing debug commands.
+
+**Finding T2 (confidence 6/10):** Health route
+(`register_health_routes.ts`) exposes a single function but
+`create_health_report.ts` pulls runtime metadata. No direct test file for
+`create_health_report.ts` was found in the test map. Verify coverage by invoking
+the route in an existing test, or add a targeted test.
+
+**Finding T3 (confidence 7/10):** `tokensave_doc_coverage` flags 7 undocumented
+symbols in `api_key_store.ts` (hashApiKey, generateApiKey, generateAdminSecret,
+createApiKeyStore, ApiKeyStore interface, findByKey, reload). Several of these are
+*security-adjacent*. Not strictly a test gap, but coupled with Finding S2 below.
+
+### 5.3 Regression safety
+
+Recent fixes `2268c7b` (rate-limiter IP source), `dd9f496` (6 code-scanning alerts),
+and `ec8f2f1` (12 Dependabot alerts) each include tests per their commit messages.
+Regression rule upheld.
+
+## 6. Code quality
+
+### 6.1 Complexity hotspots (top 6, excluding `dist/`)
+
+Source: `tokensave_complexity`. Formula: `lines + fan_out×3 + fan_in`; cyclomatic =
+branches + 1.
+
+| Rank | Function | File:line | cc | lines | returns | max_nesting |
+|---|---|---|---|---|---|---|
+| 1 | `registerExecuteRoutes` | `command-gateway/api/register_execute_routes.ts:61` | 21 | 289 | 10 | 5 |
+| 2 | `createTelegramApprovalChannel` | `command-gateway/service/request_telegram_approval.ts:56` | 17 | 174 | 7 | 4 |
+| 3 | `createApp` | `server/src/create_app.ts:162` | 16 | 124 | 2 | 5 |
+| 4 | `authorizeProxyRequest` | `request-proxy/service/proxy_auth.ts:39` | 15 | 175 | 13 | 2 |
+| 5 | `registerApprovalRoutes` | `command-gateway/api/register_approval_routes.ts:143` | 15 | 144 | 8 | 3 |
+| 6 | `executeCommand` | `command-gateway/service/execute_command.ts` | 19 | ~140 | 5 | 6 |
+
+**Finding C1 (confidence 9/10):** `registerExecuteRoutes` is 289 lines — nearly
+*ten times* the documented 30-line function cap in
+[CODE-STANDARDS.md:10](./CODE-STANDARDS.md). Split into (a) input validation,
+(b) rule-resolution + risk-analysis, (c) approval-wait, (d) execution handler.
+Each is independently testable; current tests already exist to guide the cut.
+
+**Finding C2 (confidence 9/10):** `authorizeProxyRequest` — 13 return sites in one
+function is an invariant-by-construction that's easy to break on future edits.
+Recommend decomposing into a typed decision chain (key-check → rule-check →
+approval-check → final verdict), each step returning the same tagged decision
+object the current function builds piecewise.
+
+**Finding C3 (confidence 8/10):** `executeCommand` reaches `max_nesting=6`. Deep
+nesting tends to hide error paths. Flatten with early returns; no behavior change.
+
+**Finding C4 (confidence 7/10):** `createApp` `max_nesting=5` inside a composition
+root is unusual. Each optional-collaborator branch (`if (config.telegram) { ... }`)
+can be hoisted into a named helper (`wireTelegramChannel(config)`), which also
+makes integration tests cleaner.
+
+### 6.2 File-length hotspots
+
+Seven source/test files exceed 300 lines (the
+[CODE-STANDARDS.md:9](./CODE-STANDARDS.md) cap):
+
+- `register_approval_routes.test.ts` (612) — test file, acceptable
+- `proxy_server.test.ts` (542) — test file, acceptable
+- `register_execute_routes.test.ts` (503) — test file, acceptable
+- `cli.test.ts` (485) — test file, acceptable
+- `telegram-e2e.test.ts` (473) — test file, acceptable
+- `cli.ts` (349) — production code, **over cap**
+- `register_execute_routes.ts` (349) — production code, **over cap**
+- `schema_contracts.test.ts` (344) — test file, acceptable
+
+**Finding C5 (confidence 9/10):** `cli.ts:349` and `register_execute_routes.ts:349`
+both exceed the 300-line file cap. `cli.ts` is a dispatcher for `start`/`--init`/
+`pair`/`log`/`stats`; each subcommand is a natural split point.
+
+### 6.3 Duplication
+
+`tokensave_similar` ran per-symbol (no project-wide smell list). No god classes
+(`tokensave_god_class` → 0). No dead code. Subjective spot-reads show low
+duplication — factories follow a shared pattern but each touches a distinct SQLite
+table.
+
+## 7. Operational & security posture
+
+### 7.1 Logging
+
+Pino + per-module child loggers, with a consistent `module` field. `npm test`
+output confirms structured JSON log lines for all major subsystems
+(`database`, `api-key-store`, `command-rules`, `app`, `auto-approve`, `executor`).
+
+### 7.2 Input validation at the HTTP boundary
+
+`validateExecuteInput` (internal helper in `register_execute_routes.ts:22`) is the
+pattern: explicit `typeof` + length guard, returning a typed `ValidationError`
+before the handler body. Consistently applied on the execute route. Approval
+routes also perform shape checks before acting.
+
+**Finding S1 (confidence 7/10):** There is no repo-wide boundary-validation helper.
+Each route rolls its own. That's fine today but accepts drift. Before 1.0, consider
+either (a) a shared `validate(schema, body)` helper or (b) a zod/ajv adapter, so
+new routes don't have to re-invent shape checks.
+
+### 7.3 Secret handling
+
+Three secret surfaces: API keys (`api_key_store.ts`), admin bearer token
+(`admin_secret`), Telegram bot token (`gateway_config.ts:83 getTelegramToken`).
+
+- API keys hashed on load (`hashApiKey(key, salt)`), not stored in plaintext.
+- Telegram token pulled from config or env (`getTelegramToken` returns typed).
+- `redactApiKeyName` exists and has dedicated tests (commit `2268c7b`).
+- Recent security commits (`dd9f496`, `ec8f2f1`) closed 6 + 12 alerts — trend
+  shows active hygiene.
+
+**Finding S2 (confidence 8/10):** The symbol doc-coverage output flags the entire
+API-key store surface as undocumented. For security-adjacent primitives
+(`hashApiKey`, `generateApiKey`, `generateAdminSecret`), a 1–2 line JSDoc per
+exported symbol stating the threat model (what it defends against, what it *does
+not*) is cheap insurance.
+
+### 7.4 Audit log completeness
+
+`audit_log.ts` is referenced by command-gateway; `tokensave_coupling` shows 4
+coupled files. No test-map query turned up an explicit "every-event-logs" test.
+A 1.0-worthy regression test is: for each of `{allow-by-rule, deny-by-rule,
+require-approval, approve, deny, execute-success, execute-failure, duplicate-409}`,
+assert the audit log contains exactly one row. Candidate follow-up, not a blocker.
+
+### 7.5 Rate limiting / DoS surface
+
+`registerExecuteRoutes` imports `express-rate-limit` and wires a rate limiter
+via `createRateLimiter`. `authenticate_request.ts` also contains an internal
+`createRateLimiter`/`checkRateLimit`. **Two different rate-limiter implementations
+in the same domain** — verify they're not both wired on the same route, and pick
+one as the canonical layer before 1.0. See Finding S3.
+
+**Finding S3 (confidence 6/10, medium-verify):** Potential redundant rate limiting
+in `command-gateway`. Worth a 10-minute read of the request path to confirm
+single-source-of-truth.
+
+## 8. Docs & process
+
+### 8.1 AGENTS.md link integrity
+
+Spot-checked: `docs/architecture/ARCHITECTURE.md`, `DEPENDENCY-RULES.md`,
+`DOMAIN-BOUNDARIES.md`, `docs/design/DESIGN-PRINCIPLES.md`, `PATTERNS.md`,
+`docs/quality/CODE-STANDARDS.md`, `QUALITY-GRADES.md`, `docs/specs/USER-JOURNEYS.md`,
+`docs/workflows/TASK-LIFECYCLE.md`, `REVIEW-CHECKLIST.md` — all resolve. Specs
+index at `docs/specs/README.md` resolves. `docs/context/GLOSSARY.md` and
+`DECISIONS.md` referenced but not verified for content drift (out of scope for
+this checkpoint).
+
+### 8.2 Specs vs code drift
+
+Specs directory contains `approval-channels.md`, `command-execution.md`,
+`platform-health.md`, `transparent-proxy.md`, `operator-workflows.md`. The
+`transparent-proxy.md` spec matches the shape of the new `request-proxy` domain
+— good. **But** `DOMAIN-BOUNDARIES.md` does not list `request-proxy` (Finding A1).
+
+### 8.3 QUALITY-GRADES currency
+
+Last reviewed 2026-04-11. PR #21 landed 2026-04-18 with a brand-new domain. The
+table does not include `request-proxy`. Part of the same drift as Finding A1.
+
+**Finding D1 (confidence 10/10):** `QUALITY-GRADES.md` needs a `request-proxy` row
+before 1.0.
+
+### 8.4 Semver / release discipline
+
+- 21 semver tags following the `x.y.z` convention (AGENTS rule 8: no `v` prefix) ✓
+- Latest tag: `0.8.1`
+- `package.json` version: `0.1.0-alpha.1` — **stale by 8 minor versions** ✗
+- No `CHANGELOG.md` ✗
+- No `VERSION` file ✗
+
+**Finding R1 (confidence 10/10, P0 for 1.0):** Version drift between
+`package.json` and the semver tag stream. Every `npm publish` from the tip of
+master would publish `0.1.0-alpha.1`, *not* the real version. This is a
+ship-stopper for 1.0.
+
+**Finding R2 (confidence 10/10):** No `CHANGELOG.md`. With 21 tags worth of
+history, reconstructing release notes at 1.0 is cheap now and expensive later.
+
+### 8.5 Review/workflow adherence
+
+Recent commits on master (#21, prior fixes) each pair a behaviour change with
+doc or test updates — `feat(#21)`, `fix(security)`, `docs(skills)`, `refactor`.
+Commit-type hygiene per CODE-STANDARDS §Commit Messages is solid.
+
+## 9. Release-readiness matrix
+
+| Area | Verdict | Notes |
+|---|---|---|
+| Dependency direction | ✅ clean | Enforced by CI |
+| Domain boundaries | ⚠️ doc drift (A1) | request-proxy missing |
+| Tests green | ✅ 323/323 |  |
+| Lint clean | ✅ |  |
+| Structure check | ✅ |  |
+| Complexity caps | ⚠️ 3 hotspots (C1, C2, C3) | All in newer HTTP code |
+| File-length caps | ⚠️ 2 source files over (C5) |  |
+| Semver tag stream | ✅ consistent `x.y.z` | AGENTS rule 8 |
+| package.json version | ❌ stale (R1) | Must match tag before 1.0 |
+| CHANGELOG | ❌ missing (R2) |  |
+| Security posture | ✅ trending green | 18 alerts recently closed |
+| Logging | ✅ consistent Pino |  |
+| Docs coverage (JSDoc) | ⚠️ security symbols undocumented (S2) |  |
+| Operational limits documented | ⚠️ in-memory pending store not in README (R3) |  |
+
+### 9.1 Must-fix before 1.0 (P0)
+
+1. **R1 — version drift.** Update `package.json:version` to match the next real
+   semver tag. Consider adding a CI gate that fails if `package.json.version`
+   ≠ `git describe --tags --abbrev=0` on a tag commit.
+2. **A1 + D1 — doc drift from #21.** Add `request-proxy` to
+   `DOMAIN-BOUNDARIES.md` (registry, boundary map, integration contracts) and a
+   row to `QUALITY-GRADES.md`.
+3. **R2 — CHANGELOG.** At minimum, generate a 1.0 CHANGELOG from `git log` that
+   lists every tagged release from 0.1.0 through 0.8.1 and the 1.0 summary.
+4. **C1 — `registerExecuteRoutes` decomposition.** 289 lines with `cc=21` is a
+   future-regression magnet. Split as described in §6.1.
+
+### 9.2 Should-fix before 1.0 (P1)
+
+5. **C2** — decompose `authorizeProxyRequest` into a typed decision chain.
+6. **C3** — flatten `executeCommand` from `max_nesting=6` to ≤3.
+7. **C4** — pull optional-collaborator branches out of `createApp`.
+8. **C5** — split `cli.ts` (per-subcommand) and `register_execute_routes.ts`
+   (per the C1 split).
+9. **S2** — add JSDoc to the API-key-store public surface.
+10. **S3** — audit `command-gateway` request path for redundant rate limiting.
+11. **R3** — README section on operational limits (single-process state,
+    SQLite-only).
+
+### 9.3 Nice-to-have / post-1.0 (P2)
+
+12. **S1** — shared boundary-validation helper.
+13. **T1** — dedicated tests for `stats` / `log` CLI commands.
+14. **T2** — direct test for `create_health_report`.
+15. Audit-log completeness regression test.
+
+## 10. Not in scope (explicit)
+
+- No code refactors were applied. Every finding above is a *candidate* for a
+  follow-up issue.
+- No tests were added.
+- No dependency upgrades or `npm audit` triage — that lives in
+  `gh-security-and-quality`.
+- No SonarCloud issue pull — separate skill (`sonar`).
+- No runtime load / performance benchmarking.
+- No UI/UX audit of the admin approval page.
+
+## 11. What already exists (pre-1.0 work that's quietly done)
+
+- Mechanical enforcement of dependency direction.
+- Pino structured logging across every module.
+- Rate limiting on the execute route.
+- API-key hashing with salt.
+- Audit log with `better-sqlite3`.
+- Telegram approval, web approval, auto-approve, and multi-approval channels.
+- Transparent proxy with API-key + Telegram modes (PR #21).
+- Security-alert triage cadence (skills: `gh-security-and-quality`, `sonar`).
+- Review / task-lifecycle docs and checklists.
+
+## 12. Failure modes (one per new codepath, for 1.0 hardening)
+
+| Codepath | Realistic failure | Test? | Handled? | User experience |
+|---|---|---|---|---|
+| `authorizeProxyRequest` | Upstream creds rotated mid-request | partial | yes (returns typed reject) | 401 with specific code |
+| `createTelegramApprovalChannel` | Telegram API 5xx during callback | partial | retry-via-timeout | request eventually times out |
+| `executeCommand` | Child process exceeds stdout buffer | unknown | unknown | **potential silent truncation** — verify |
+| `registerExecuteRoutes` duplicate detection | Race between two in-flight requests with same ID | yes (409 test) | yes | clear 409 |
+| In-memory `pending_request_store` | Server restart mid-approval | not applicable | no (advertised) | pending request lost |
+| SSE `/admin/approvals/stream` | Client disconnects uncleanly | unknown | verify | connection cleanup |
+
+The `executeCommand` stdout-buffer case is the most concerning unknown; others are
+either handled or documented. Recommend one targeted test before 1.0.
+
+## 13. Outside-voice note
+
+`/plan-eng-review` usually calls an outside AI (Codex / independent subagent) to
+challenge the plan. This checkpoint reviews *existing code*, not a plan. An outside
+voice pass on 1.0 readiness should run against *this report* before the 1.0 cut —
+not as part of this PR.
+
+## 14. How to read this report
+
+- Findings are labelled with a letter (A=architecture, C=complexity/code,
+  D=docs, R=release, S=security, T=testing) + number, and a confidence score
+  (1–10).
+- Each finding has a file:line anchor or a `tokensave_*` query that produced it.
+- P0/P1/P2 buckets in §9 are the single place to prioritise.
+
+---
+
+*Generated on branch `feature/25` for issue #25. No behaviour changes introduced
+by this PR — report-only.*

--- a/docs/quality/PRE-1.0-CHECKPOINT.md
+++ b/docs/quality/PRE-1.0-CHECKPOINT.md
@@ -18,12 +18,12 @@
 
 ## 1. Executive verdict
 
-**Ship 1.0 after closing the four Must-fix items listed in §9.** Structurally the
+**Ship 1.0 after closing the three Must-fix items listed in §9.** Structurally the
 codebase is in good shape: zero circular dependencies, zero recursion cycles, zero
 dead code, zero unused imports, zero `TODO`/`FIXME`/`@ts-expect-error` markers, and
 a mechanically-enforced layered dependency direction (`Types → Config → Repository
 → Service → Runtime → UI/API`). The gaps that block a confident 1.0 cut are
-*release-hygiene* gaps (version/changelog discipline) and a small number of
+a *release-hygiene* gap (missing `CHANGELOG.md`) and a small number of
 *complexity hotspots* in the newer HTTP-boundary code.
 
 ## 2. Repo snapshot
@@ -46,7 +46,7 @@ a mechanically-enforced layered dependency direction (`Types → Config → Repo
 | Lint | clean | `npm run lint` |
 | Structure check | clean | `npm run check:structure` |
 | Semver tags in history | 21 (latest: `0.8.1`) | `git tag --list` |
-| `package.json` version | `0.1.0-alpha.1` | `package.json:3` |
+| `package.json` version | `0.1.0-alpha.1` (placeholder — CI overrides) | `package.json:3`, `.github/workflows/ci.yml:137` |
 | `CHANGELOG.md` | absent | `ls` |
 | `VERSION` file | absent | `ls` |
 
@@ -129,7 +129,7 @@ another. This is consistent with the documented UI-layer rule (UI may only impor
 - **In-memory pending-request store** (documented in
   [QUALITY-GRADES.md:17](./QUALITY-GRADES.md)). A restart drops every in-flight
   approval. Not a bug; an advertised constraint — but a 1.0 release should state it
-  in the README's operational-limits section. See Finding R1.
+  in the README's operational-limits section. See Finding R3.
 
 ## 5. Testing review
 
@@ -321,14 +321,22 @@ before 1.0.
 
 - 21 semver tags following the `x.y.z` convention (AGENTS rule 8: no `v` prefix) ✓
 - Latest tag: `0.8.1`
-- `package.json` version: `0.1.0-alpha.1` — **stale by 8 minor versions** ✗
+- `package.json` version: `0.1.0-alpha.1` — **intentional placeholder** ✓
 - No `CHANGELOG.md` ✗
 - No `VERSION` file ✗
 
-**Finding R1 (confidence 10/10, P0 for 1.0):** Version drift between
-`package.json` and the semver tag stream. Every `npm publish` from the tip of
-master would publish `0.1.0-alpha.1`, *not* the real version. This is a
-ship-stopper for 1.0.
+**Finding R1 — resolved / not a drift.** The `version` field in
+`package.json` is a placeholder. The publish pipeline derives the real
+version from the nearest semver tag in
+`.github/workflows/ci.yml` (`version` job, lines 46–108) and overwrites
+`package.json` at publish time with
+`npm version "$VERSION" --no-git-tag-version --allow-same-version`
+(line 137) before `npm publish`. The committed value is therefore
+expected to lag the tag stream and is not a ship blocker. No action
+required; an optional hardening would be a CI comment in
+`package.json` (via a separate `.md` or a `publishConfig` note) that
+states the field is CI-managed, to prevent future readers from
+re-flagging it.
 
 **Finding R2 (confidence 10/10):** No `CHANGELOG.md`. With 21 tags worth of
 history, reconstructing release notes at 1.0 is cheap now and expensive later.
@@ -351,7 +359,7 @@ Commit-type hygiene per CODE-STANDARDS §Commit Messages is solid.
 | Complexity caps | ⚠️ 3 hotspots (C1, C2, C3) | All in newer HTTP code |
 | File-length caps | ⚠️ 2 source files over (C5) |  |
 | Semver tag stream | ✅ consistent `x.y.z` | AGENTS rule 8 |
-| package.json version | ❌ stale (R1) | Must match tag before 1.0 |
+| package.json version | ✅ CI-managed | Placeholder overwritten by publish pipeline |
 | CHANGELOG | ❌ missing (R2) |  |
 | Security posture | ✅ trending green | 18 alerts recently closed |
 | Logging | ✅ consistent Pino |  |
@@ -360,16 +368,18 @@ Commit-type hygiene per CODE-STANDARDS §Commit Messages is solid.
 
 ### 9.1 Must-fix before 1.0 (P0)
 
-1. **R1 — version drift.** Update `package.json:version` to match the next real
-   semver tag. Consider adding a CI gate that fails if `package.json.version`
-   ≠ `git describe --tags --abbrev=0` on a tag commit.
-2. **A1 + D1 — doc drift from #21.** Add `request-proxy` to
+1. **A1 + D1 — doc drift from #21.** Add `request-proxy` to
    `DOMAIN-BOUNDARIES.md` (registry, boundary map, integration contracts) and a
    row to `QUALITY-GRADES.md`.
-3. **R2 — CHANGELOG.** At minimum, generate a 1.0 CHANGELOG from `git log` that
+2. **R2 — CHANGELOG.** At minimum, generate a 1.0 CHANGELOG from `git log` that
    lists every tagged release from 0.1.0 through 0.8.1 and the 1.0 summary.
-4. **C1 — `registerExecuteRoutes` decomposition.** 289 lines with `cc=21` is a
+3. **C1 — `registerExecuteRoutes` decomposition.** 289 lines with `cc=21` is a
    future-regression magnet. Split as described in §6.1.
+
+> R1 (package.json version drift) was investigated and dropped: the
+> publish pipeline overwrites the field at publish time
+> (`.github/workflows/ci.yml:137`), so the committed placeholder is
+> intentional. See §8.4.
 
 ### 9.2 Should-fix before 1.0 (P1)
 

--- a/meta/gstack-overview.md
+++ b/meta/gstack-overview.md
@@ -1,9 +1,9 @@
 # gstack — how the three skills fit together
 
 `gstack` is the label we use for the GitHub-issue-driven automation loop in
-this repo. It is not a single skill: it is three skills layered on top of
-each other, plus `github-pr-fixer` as a downstream helper when a PR needs
-babysitting.
+this repo. It is three skills layered on top of each other. `github-pr-fixer`
+is **not** part of the chain — it is a separate, manual-slash-only tool the
+owner may choose to run on a PR. Nothing in gstack invokes it automatically.
 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
@@ -19,7 +19,7 @@ babysitting.
 │   (reference manual: issues, PRs, checks, reviews, code scanning)    │
 └──────────────────────────────────────────────────────────────────────┘
 
-         If PR checks fail or a reviewer posts comments → github-pr-fixer
+         (PR babysitting is NOT automatic — owner may run `/github-pr-fixer` manually)
 ```
 
 ## Role of each skill
@@ -36,17 +36,31 @@ duplicating command blocks.
 Takes a single issue identifier (`123`, `owner/repo#123`, or a full URL) and
 drives it through:
 
-1. Fetch & understand the issue
-2. Claim (`@me` + `claim-label` + pick-up comment)
-3. Plan (light inline or formal plan for big changes)
-4. Build — delegates to the matching implementation skill
-   (`new-feature`, `bug-fix`, `small-change`, `refactor`, `add-domain`)
-5. Test — discovers the repo's toolchain (`package.json`, `Makefile`, `*.sln`, ...)
-6. Ship — push branch, open PR with `Closes #N`
-7. Hand off — comment PR URL on the issue
+1. Fetch & understand the issue (channel: **issue**)
+2. Claim — `@me` + `claim-label` + pick-up comment on the issue
+3. Plan — post plan as issue comment and wait for owner approval (channel:
+   **issue**; no code exists yet)
+4. **Open the DRAFT PR before writing any code.** This is the fixed
+   channel-switch point: from this moment forward every question, status
+   update, decision request, and failure report goes on the PR thread,
+   not the issue and not the console
+5. Build — delegates to the matching implementation skill
+   (`new-feature`, `bug-fix`, `small-change`, `refactor`, `add-domain`).
+   Delegated skills inherit the "PR thread only" rule
+6. Test — discover the repo's toolchain (`package.json`, `Makefile`,
+   `*.sln`, …) and run validation locally
+7. Mark the PR ready — `gh pr ready`, update test-plan section, post
+   final `gstack:handoff` on the issue and `gstack:status` on the PR
 
-On failure: swap `claim-label` → `fail-label`, post a detailed comment,
-leave the branch intact, surface the failure in chat.
+**Communication protocol.** All user interaction goes through GitHub —
+issue thread before the draft PR exists, PR thread from draft-open
+onward. Never the Claude console. This binds `gstack-gh` and every skill
+it delegates to.
+
+On failure: swap `claim-label` → `fail-label`, post a `gstack:failure`
+comment on whichever channel is currently active (issue pre-draft-PR, PR
+after), cross-link if the failure is on the PR. Leave branch and draft
+PR intact. Surface the failure in chat.
 
 **Never merges.** Merge/land is always a human decision.
 
@@ -72,12 +86,14 @@ Safety rails: never auto-merge, never `max-per-cycle > 3` without consent,
 stop touching an issue after two `fail-label` cycles, confirm repo before
 running in `cron` mode.
 
-### `github-pr-fixer` — downstream helper
-Not part of the gstack chain, but often invoked right after `gstack-gh`
-opens a PR. It drives a PR to green through up to three fix rounds, handles
-reviewer comments (human or Copilot), can open a PR from the current
-branch, and can close a ready release PR. Also uses `gh-cli-guide` as its
-sole source of `gh` syntax.
+### `github-pr-fixer` — MANUAL SLASH-ONLY tool (not part of the chain)
+Invoked ONLY by the user typing `/github-pr-fixer`. gstack never chains to
+it, never auto-invokes it, and never posts handoff comments that act as
+triggers. When the owner chooses to run it, it drives a PR to green through
+up to five fix rounds, handles reviewer comments (human or Copilot), can
+open a PR from the current branch, and can close a ready release PR. Its
+frontmatter carries `disable-model-invocation: true` to enforce this
+belt-and-braces alongside the prose rule.
 
 ## Typical end-to-end invocation
 
@@ -130,20 +146,21 @@ them, it must stop and park the issue with `fail-label` instead of fudging.
 2. **Issue ↔ PR binding:** every PR body contains `Closes #<N>`, and a
    `gstack:handoff` comment on the issue links to the PR URL. The
    connection is discoverable from either side.
-3. **PR babysitting:** once the PR is open, `github-pr-fixer` owns the
-   check-fix / reviewer-comment loop. `gstack-gh` does not duplicate it.
-4. **Closure requires explicit user consent:** no part of the chain
-   (`gstack-gh`, `gstack-full`, `github-pr-fixer`) merges, closes, or
-   release-tags a PR without a direct instruction from the user. That
-   instruction is valid whether it arrives in chat or as a comment on the
-   PR/issue.
+3. **PR babysitting is NOT automatic.** Once `gstack-gh` opens the PR and
+   posts its `gstack:handoff` comment, gstack stops touching it. The owner
+   chooses whether to run `/github-pr-fixer` manually for CI fixing,
+   reviewer-comment handling, or closure. No skill in the chain may invoke
+   `github-pr-fixer` on its own.
+4. **Closure requires explicit user consent:** `gstack-gh` and `gstack-full`
+   never merge, close, or release-tag a PR. If the owner wants that work
+   driven by an automation, they invoke `/github-pr-fixer` themselves.
 5. **All Q&A flows through the issue or PR.** No skill in the chain may
    ask the user a question through the Claude console. Questions are
    posted as issue/PR comments (with a `gstack:question:<uuid>` marker),
    and the skill polls the same thread every `poll-seconds` (default `60`)
    for a reply. Answers are acknowledged with a follow-up comment before
-   work resumes. This rule applies to `github-pr-fixer` and any
-   implementation skill gstack delegates to.
+   work resumes. This rule applies to every implementation skill gstack
+   delegates to.
 
 ## What gstack does NOT do
 

--- a/meta/gstack-workflow.md
+++ b/meta/gstack-workflow.md
@@ -1,0 +1,411 @@
+# gstack-workflow — how gstack-full, gstack-gh, and github-pr-fixer fit together
+
+## Purpose
+
+This document maps the runtime relationship between the three skills that drive
+GitHub-issue automation in this repo: `gstack-full`, `gstack-gh`, and
+`github-pr-fixer`. It is aimed at contributors who need to extend one of those
+skills, debug a misbehaving loop, or reason about which skill owns a given
+concern at a given moment. For the higher-level taxonomy (including
+`gh-cli-guide` as the reference manual) start with
+[`gstack-overview.md`](./gstack-overview.md); this doc picks up where that one
+stops and focuses on interaction, polling, and the contested boundaries between
+the three active skills.
+
+## At a glance
+
+| Skill              | Entry point                                   | Scope                                                                  | Stops when                                                                                                           |
+| ------------------ | --------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `gstack-full`      | `/gstack-full label=… repo=…` (or cron)       | Label-driven queue across many issues; picks N per cycle and delegates | `mode=once` completes; two `fail-label` cycles on the same issue; session ends (in `loop` mode); user stops the cron |
+| `gstack-gh`        | `/gstack-gh <issue>` (direct or from `-full`) | One issue end-to-end: claim → plan → **open DRAFT PR before writing any code** → build → test → mark PR ready → post `gstack:handoff` → STOP. Channel switches from issue to PR at draft-open. | Draft PR opened, code pushed, PR marked ready, `gstack:handoff` posted; or failure parks the issue/PR with `fail-label` |
+| `github-pr-fixer`  | **MANUAL SLASH-ONLY** — `/github-pr-fixer`. Never auto-invoked, never chained from another skill, `disable-model-invocation: true` | PR lifecycle: CI-green loop, reviewer comments, release-closure | PR merged/closed; 5-round cap exhausted (awaits explicit resume); user tells it to stop watching                     |
+
+## High-level workflow
+
+```mermaid
+flowchart TD
+    A[Labelled issue<br/>e.g. ready-for-claude] --> B{gstack-full<br/>cycle}
+    B -->|already has<br/>claim-label or fail-label| B1[Skip]
+    B -->|picked| C[gstack-gh<br/>claims issue]
+    C --> D[Add claim-label<br/>create feature/N<br/>pick-up comment]
+    D --> E{Plan size}
+    E -->|large| F[Post plan comment<br/>poll issue for owner reply]
+    E -->|small| G[3-line plan<br/>proceed]
+    F -->|owner approves| G
+    F -->|timeout / reject| Z1[fail-label + park]
+    G --> G2[Open DRAFT PR<br/>BEFORE any code<br/>channel: issue → PR]
+    G2 --> H[Build + local tests<br/>all Q&A on PR thread]
+    H -->|tests fail| Z1
+    H -->|green| I[Push commits<br/>gh pr ready]
+    I --> J[Post gstack:handoff on issue<br/>final gstack:status on PR<br/>STOP]
+    J -. owner decides .-> U[/User types<br/>/github-pr-fixer/]
+    U --> K[gh pr checks --watch]
+    K -->|CI fail| L{Fix round<br/>≤ 5?}
+    L -->|yes| M[Diagnose + fix + push] --> K
+    L -->|no| Z2[Park; await resume]
+    K -->|CI green| N[5-min poll loop<br/>laconic subagent]
+    N -->|reviewer comment| O[Address + push] --> K
+    N -->|bot confirmation| P[Resolve threads<br/>via GraphQL] --> N
+    N -->|owner: close/land/tag| Q[release-closure]
+    Q --> R[Merge / tag / cleanup]
+    R --> S[Apply done-label to issue<br/>final gstack:status]
+
+    classDef manual fill:#fff4cc,stroke:#d4a017,stroke-width:2px;
+    class U manual;
+```
+
+The dotted edge from `J` to `U` is the crucial boundary: gstack-gh terminates
+at `J`. Everything below `U` only runs if the owner explicitly types
+`/github-pr-fixer` on the console. No comment, label, or event triggers it.
+
+## Per-skill sections
+
+### `gstack-full`
+
+**Summary.** A label-driven orchestrator that watches one GitHub repo for
+issues tagged with a caller-supplied label, ranks them, picks up to
+`max-per-cycle` (default 1), and delegates each to `gstack-gh` in `mode=once`.
+It never writes code itself and never merges.
+
+**Extended description.** Each cycle runs a discovery `gh issue list` that
+explicitly filters out issues already carrying `claim-label` (in-flight) or
+`fail-label` (parked), ranks oldest-first unless priority labels
+(`p0`, `p1`, …) are present, picks up to `max-per-cycle`, and hands each
+issue off with `/gstack-gh owner/repo#N`. If `gstack-gh` reports failure, the
+cycle stops — it does not pile up `needs-human` issues. Scheduling has three
+modes: `once` (single sweep), `loop` (in-session via the `/loop` skill, either
+timed or self-paced via `ScheduleWakeup`), and `cron` (durable remote agent
+via `CronCreate` / `/schedule`; survives session death). Preconditions are
+revalidated every cycle: `gh auth`, clean working tree, on base branch. A hard
+owner-only gate resolves the primary owner from
+`gh repo view --json owner --jq .owner.login` every cycle and ignores state-
+changing directives from any other login. Safety rails include: never
+auto-merge, never `max-per-cycle > 3` without user consent, stop touching an
+issue after two `fail-label` cycles, and confirm the target repo before
+starting a cron schedule. A first-run startup checklist requires confirming
+`label`, `repo`, `mode` in one line and running a dry `once` discovery before
+the real schedule starts.
+
+```mermaid
+sequenceDiagram
+    participant Owner
+    participant Full as gstack-full
+    participant GH as GitHub
+    participant GGH as gstack-gh
+    Owner->>Full: /gstack-full label=X repo=O/R
+    Full->>GH: gh issue list --label X (exclude claim/fail)
+    GH-->>Full: candidate issues
+    Full->>Full: rank + pick max-per-cycle
+    Full->>GGH: /gstack-gh O/R#N (mode=once)
+    GGH-->>Full: success (PR url) | failure
+    Full->>Owner: one-line summary
+    Full->>Full: sleep until next interval / exit if once
+```
+
+### `gstack-gh`
+
+**Summary.** Drives one issue from claim through a merge-ready PR. Sole
+owner of the ticket lifecycle for the duration, with the hard rule that
+every question, status update, decision request, and hand-off goes through
+GitHub — never the Claude console. **Opens the PR as a DRAFT the instant
+the plan is approved, before the first file is edited**, so the PR becomes
+the communication channel for implementation. Every delegated
+implementation skill inherits the same protocol. When local validation
+passes the skill flips the PR out of draft and STOPS. It does NOT invoke
+`github-pr-fixer`; that skill is manual-slash-only.
+
+**Channel rule.** Issue thread for fetch/claim/plan/plan-approval (no code
+exists yet). PR thread from the moment the draft PR is opened onward (code
+is being written). Transition point is fixed and singular.
+
+**Extended description.** The flow is: fetch issue → claim (`@me` +
+`claim-label` + `feature/<N>` branch + pick-up `gstack:status` comment) →
+plan → build → test → ship → handoff. Every bot comment carries a
+machine-readable marker `<!-- gstack:<kind>:<uuid> -->` where `<kind>` is one
+of `status`, `question`, `answer-ack`, `plan`, `handoff`, `failure`. When a
+question is outstanding the skill enters a polling loop
+(`poll-seconds`, default 60) against `gh issue view --json comments`, filtered
+by `createdAt > ASKED_AT` AND `author.login == OWNER`. The owner filter is
+mandatory and mechanical: no relaxation to `!= bot-login` is allowed. A 60-
+minute polling cap parks the issue with `fail-label`. Plan-approval discipline
+is explicit and hard: a console invocation is NOT plan approval; if the plan
+comment promised polling, the skill MUST poll — prior breaches of this rule
+are captured in agent memory as a real failure mode. `Monitor` is preferred
+over a blocking sleep loop so the session stays responsive. Large changes
+(architecture, public API, >5 files) require formal plan-then-wait; small
+changes post a 3-line plan and proceed. Build delegates to the repo's matching
+implementation skill (`new-feature`, `bug-fix`, `small-change`, `refactor`,
+`add-domain`). Tests are discovered from `package.json`/`Makefile`/`*.sln`/
+`AGENTS.md`. The PR body MUST contain `Closes #<N>`, the branch MUST be
+`feature/<N>` (no slug). The draft PR is opened at the build→build
+transition (step 4 in the skill), BEFORE any file is edited, with a body
+announcing the channel change and a `gstack:handoff-to-pr` pointer posted
+on the issue. All implementation Q&A, status, and decision-polling happens
+on the PR thread from that point on. When `npm run lint && npm test && npm
+run build` (or the repo equivalent) passes, the skill calls `gh pr ready
+<N>` to flip the PR out of draft, posts the final `gstack:handoff` on the
+issue, and exits. It never merges, never polls the PR for reviewer/CI
+feedback, and never invokes any downstream skill. `done-label` is applied
+only if the owner later asks the skill directly, after a merge has happened
+through an independent path.
+
+```mermaid
+sequenceDiagram
+    participant Owner
+    participant GGH as gstack-gh
+    participant GH as GitHub
+    Owner->>GGH: /gstack-gh #N
+    GGH->>GH: claim (assignee, claim-label, feature/N, pick-up on issue)
+    GGH->>GH: post plan on issue (gstack:plan)
+    GGH->>GH: poll issue comments (author==owner)
+    Owner->>GH: approval comment on issue
+    GH-->>GGH: reply surfaced
+    Note over GGH,GH: Channel switch: issue → PR
+    GGH->>GH: gh pr create --draft (Closes #N)
+    GGH->>GH: gstack:handoff-to-pr pointer on issue
+    GGH->>GGH: build + local tests (all Q&A on PR thread)
+    GGH->>GH: push commits; gh pr ready <N>
+    GGH->>GH: gstack:handoff on issue; final gstack:status on PR
+    GGH-->>Owner: EXIT (no downstream invocation)
+```
+
+### `github-pr-fixer`
+
+**Summary.** Babysits an open PR until it is merged, closed, or stopped by
+user instruction. Drives CI to green in up to 5 fix rounds, handles reviewer
+comments (human and bot) in a separate 5-round budget, resolves Copilot-
+confirmed review threads via GraphQL, and executes release-closure when the
+owner explicitly asks.
+
+**Invocation rule (hard).** This skill runs ONLY when the owner explicitly
+types `/github-pr-fixer` on the console. Its frontmatter carries
+`disable-model-invocation: true`, and `gstack-gh`, `gstack-full`,
+`gh-security-and-quality`, and the `pr-cycle` agent are all forbidden from
+auto-invoking it. Handoff comments, labels, PR events, or CI failures do
+NOT trigger it — only the user's slash command does.
+
+**Extended description.** After being invoked on a PR it first uses
+`gh pr checks <N> --watch --fail-fast` as a blocking call instead of polling
+CI — one syscall that returns only when every check is in a terminal state.
+Non-zero exit jumps straight to `references/check-diagnosis.md`; zero exit
+arms the 5-minute reviewer/closure poll. Every 5-minute poll cycle MUST run
+inside a laconic subagent (typically `general-purpose`) briefed with the PR
+number, the last comment-id watermark, the trigger phrase list
+(`merge it`, `land it`, `release as X.Y.Z`, `close this`, `scope: …`,
+`tag X.Y.Z`), the gh-auth login to treat as a self-echo, and a counterpart
+rule that ALL bot/Copilot comments are surfaced regardless of tone. The
+subagent returns a single line: `nothing to do`, `action: …`, `fail: …`,
+`close: …`, `tag-ok: …`, `scope: …`, `merged`, or `closed`. Watermark
+discipline is `highest *processed* id, never highest *seen* id`, with three
+valid priming strategies to avoid losing instructions posted between
+`gh pr create` and the first poll. Fix rounds cap at 5; after exhaustion the
+skill stops and reports the blocking checks — it does NOT resume without an
+explicit "resume fixes" / "take another look" from the owner. When a push
+addresses Copilot comments, the skill posts a plain resolution summary (no
+`@`-mention of Copilot — the agent typically lacks permission to invoke the
+reviewer). When Copilot replies with a natural-language confirmation, the
+skill resolves the confirmed review threads itself via the GraphQL
+`resolveReviewThread` mutation, because Copilot does not close its own
+threads. State-changing directives (merge/close/tag/scope/resume) are acted on
+ONLY when the comment author is the primary repo owner; everything else is
+advisory and gets a one-time "only the repo owner can authorise this" reply.
+Stops on: PR merged/closed, explicit stop instruction, or 5 empty poll cycles
+followed by owner confirmation to pause.
+
+```mermaid
+sequenceDiagram
+    participant Owner
+    participant Fixer as github-pr-fixer
+    participant Sub as Poll subagent
+    participant GH as GitHub
+    participant Copilot
+    Fixer->>GH: gh pr checks N --watch --fail-fast
+    GH-->>Fixer: exit 0 (green)
+    loop every 5 min while PR open
+        Fixer->>Sub: brief (watermark, owner, triggers, self-echo)
+        Sub->>GH: gh pr view --json comments,reviews,checks
+        Sub-->>Fixer: one-line: nothing to do | action | close
+    end
+    Copilot->>GH: "All fixes look correct"
+    Fixer->>GH: resolveReviewThread (GraphQL) per confirmed thread
+    Owner->>GH: "release as X.Y.Z"
+    Fixer->>GH: release-closure (merge, tag, cleanup)
+```
+
+## Overlaps and boundaries
+
+The three skills share two patterns — **polling GitHub comments for an
+owner reply** and **refusing to change PR state without the repo owner's
+explicit instruction** — but they are NOT chained. `gstack-full` and
+`gstack-gh` form a two-step pipeline (label sweep → per-issue drive); both
+stop hard at PR creation. `github-pr-fixer` is an independent tool the
+owner may choose to run afterwards — there is no automatic baton-pass to
+it. The overlap is structural (same owner-gating idiom, same polling
+template) rather than temporal (the skills never run against the same
+thread for the same purpose).
+
+- **Plan-approval polling** lives entirely in `gstack-gh`, on the ISSUE
+  thread (pre-code phase). `gstack-full` never reads plan comments.
+- **Implementation-phase polling** also lives in `gstack-gh`, but on the
+  PR thread after the draft PR is opened. Same owner-login filter, same
+  watermark discipline — different channel. Delegated implementation
+  skills inherit this rule: they comment on the PR, never the issue,
+  never the console.
+- **Discovery polling** (labelled-issue sweep) is exclusive to `gstack-full`.
+  The other two skills operate on a single issue/PR and never scan the
+  backlog.
+- **CI-watching** is exclusive to `github-pr-fixer`, which uses
+  `gh pr checks --watch` as a blocking call rather than a poll.
+  `gstack-gh` runs *local* validation before pushing but never waits on
+  remote CI — once the PR is open the hand-off is immediate.
+- **Reviewer-comment loop** (human reviewers, Copilot, SonarCloud decorations,
+  thread resolution via GraphQL) is exclusive to `github-pr-fixer`.
+- **Merge / close / release-closure** is exclusive to `github-pr-fixer`, and
+  only on an explicit owner directive. Neither `gstack-full` nor
+  `gstack-gh` may merge or close; they forbid themselves from doing so.
+- **Owner-only gate** is implemented independently by all three skills
+  (every one re-resolves the owner via `gh repo view --json owner`), which is
+  intentional defence-in-depth rather than a true overlap — each skill can
+  run in isolation.
+- **Issue-comment polling** appears in both `gstack-full` (cron-fire read of
+  the label list) and `gstack-gh` (plan-approval / decision polling). They
+  never read the same thread for the same purpose.
+
+```mermaid
+flowchart LR
+    subgraph Full[gstack-full]
+        F1[Label discovery]
+        F2[Rank + pick]
+        F3[Delegate to gstack-gh]
+        F4[Cycle reporting]
+    end
+    subgraph GGH[gstack-gh]
+        G1[Claim + branch + pick-up<br/>channel: issue]
+        G2[Plan-approval poll<br/>channel: issue]
+        GD[Open DRAFT PR<br/>before code<br/>channel switches to PR]
+        G3[Build + local test<br/>channel: PR]
+        G4[gh pr ready]
+        G5[gstack:handoff on issue<br/>final gstack:status on PR]
+    end
+    subgraph Fixer[github-pr-fixer]
+        P1[gh pr checks --watch]
+        P2[Fix round loop ≤5]
+        P3[Reviewer-comment poll<br/>5-min laconic subagent]
+        P4[GraphQL thread resolution]
+        P5[Release-closure]
+    end
+    F3 --> G1
+    G5 -. owner manually types<br/>/github-pr-fixer .-> P1
+    P5 -. done-label .-> Full
+
+    classDef overlap fill:#fff3bf,stroke:#f59f00,stroke-width:2px,color:#000
+    class G2,P3 overlap
+```
+
+The yellow nodes (`Plan-approval poll` and `Reviewer-comment poll`) are the
+**overlap zone**: both are "poll a GitHub thread until the owner replies".
+They share an enforcement pattern (owner-login filter, watermark discipline,
+self-echo avoidance) but never run at the same time on the same thread —
+`gstack-gh` has exited by the time `github-pr-fixer`'s poll could be armed,
+and `github-pr-fixer` only runs if the owner manually invokes it.
+
+**Who owns what (contested concerns).**
+
+- **Plan approval:** `gstack-gh` (polls issue for owner reply).
+- **First push:** `gstack-gh` (creates `feature/<N>` and the PR).
+- **Draft → ready transition:** ambiguous in the source files — none of the
+  three SKILL.md files mandate opening the PR as draft, nor describe an
+  explicit ready transition. Treat as owned by `gstack-gh` at PR creation
+  time unless future instructions say otherwise.
+- **CI watching:** `github-pr-fixer` (blocking `gh pr checks --watch`, then
+  5-min poll) — but ONLY if the owner manually invokes it. No skill
+  auto-starts this watch.
+- **Reviewer feedback loop:** `github-pr-fixer` (separate 5-round budget),
+  only under manual invocation.
+- **GraphQL thread resolution after Copilot confirms:** `github-pr-fixer`,
+  only under manual invocation.
+- **Merge:** `github-pr-fixer` (only on explicit owner directive inside a
+  manual invocation) OR the owner merges by hand via `gh pr merge`.
+  Nothing in the gstack chain merges on its own.
+- **Post-merge cleanup + `done-label` on the issue:** `github-pr-fixer`
+  during release-closure, or the owner applies the label manually. The
+  gstack chain does not automatically apply `done-label`.
+- **Backlog re-sweep after closure:** `gstack-full` (on the next scheduled
+  cycle — the just-closed issue now has `done-label` and drops out of the
+  query).
+
+## Handoff points
+
+| From              | To                 | Signal                                                                                                                 |
+| ----------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `gstack-full`     | `gstack-gh`        | Direct invocation `/gstack-gh owner/repo#N claim-label=… fail-label=… done-label=…` in `mode=once`, one per picked issue |
+| `gstack-gh` (plan)| `gstack-gh` (channel-switch) | Polled owner reply on the ISSUE with `author.login == OWNER` and `createdAt > ASKED_AT`                             |
+| `gstack-gh` (channel-switch) | `gstack-gh` (build) | `gh pr create --draft` succeeds; `gstack:handoff-to-pr` pointer posted on issue; all subsequent Q&A moves to PR comments |
+| `gstack-gh` (build) | delegated impl skill | Skill invocation brief explicitly forbids console and issue comments; all decision requests must go on PR #<N>      |
+| `gstack-gh`       | (exit — no skill) | `gh pr ready` succeeds; `gstack:handoff` comment on issue + final `gstack:status` on PR; `gstack-gh` exits. No downstream skill is invoked. |
+| Owner (manual)    | `github-pr-fixer`  | Owner types `/github-pr-fixer` on the console after reviewing the PR. This is the ONLY trigger for `github-pr-fixer`. |
+| `github-pr-fixer` (watch) | itself (fix round) | `gh pr checks --watch` exits non-zero → `references/check-diagnosis.md`                                       |
+| `github-pr-fixer` (watch) | itself (poll)      | `gh pr checks --watch` exits zero → arm 5-minute reviewer/closure poll                                        |
+| Poll subagent     | `github-pr-fixer` parent | One-line return: `nothing to do` / `action: …` / `fail: …` / `close: …` / `tag-ok: …` / `scope: …` / `merged` / `closed` |
+| `github-pr-fixer` (poll)  | release-closure    | Owner-authored comment containing `merge it` / `land it` / `close this` / `release as X.Y.Z` / `tag X.Y.Z`      |
+| `github-pr-fixer` (release-closure) | `gstack-gh` step 8 residual | Apply `done-label` to issue; post final `gstack:status` on the issue summarising what shipped         |
+| `gstack-gh` (any step) | human (via issue) | Step fails → remove `claim-label`, add `fail-label`, post `gstack:failure` comment, exit                          |
+| `github-pr-fixer` | human              | 5 fix rounds exhausted → park and await explicit `resume fixes` / `take another look`                                 |
+
+## Known gotchas
+
+- **Console invocation is NOT plan approval.** `gstack-gh` must still post the
+  plan comment and poll the issue; skipping the wait has caused a real
+  incident on this project.
+- **The PR is opened as DRAFT before any code is written.** This is the
+  fixed channel-switch point. If you catch yourself editing files before
+  the draft PR exists, stop, open the draft PR, and resume. The PR body
+  must explicitly announce that communication has moved from the issue
+  to the PR thread.
+- **No console communication, ever.** This applies to `gstack-gh` AND every
+  skill it delegates to (`new-feature`, `bug-fix`, `small-change`,
+  `refactor`, `add-domain`). Brief every delegation with: "all user
+  communication goes on PR #<N>; never use the console."
+- **Owner-login filter is mandatory in every poll.** `select(.author.login == OWNER)`
+  cannot be relaxed to `!= bot-login` — drive-by human comments must be
+  rejected for state changes.
+- **Watermark = highest *processed* id, never highest *seen* id.** A naive
+  `max(comment_id)` prime can drop an instruction the owner posts in the
+  ~60s between `gh pr create` and the first poll.
+- **Self-echo filter is mandatory** when gh-auth user and repo owner are the
+  same person: the subagent must treat comments from the gh-auth login as
+  echoes unless they contain a trigger phrase.
+- **Bot/Copilot comments are ALWAYS surfaced by the subagent.** The parent
+  decides whether a Copilot "all good" means "resolve threads via GraphQL"
+  or "new concern → round N+1".
+- **`github-pr-fixer` is manual-slash-only.** `disable-model-invocation: true`
+  in its frontmatter plus explicit prose in every related SKILL/agent file.
+  If you find yourself reasoning "the next step is to invoke
+  github-pr-fixer", STOP — the next step is to exit and wait for the owner
+  to type `/github-pr-fixer` themselves.
+- **5-round cap on `github-pr-fixer`** (check-fix rounds) + a separate
+  5-round budget for reviewer-comment rounds. Exhaustion requires explicit
+  owner resume — never silently keep going.
+- **`gh pr checks --watch` beats 5-minute polling while CI is running.**
+  The 5-minute poll is only for post-CI reviewer/closure feedback.
+- **Every 5-minute poll cycle runs in a laconic subagent** returning one
+  line. Keeps the parent context clean.
+- **No `@`-mention of Copilot** after fix-push resolution summaries — the
+  agent typically lacks permission to invoke the reviewer; the owner
+  re-triggers Copilot manually if they want a re-review.
+- **Copilot does not close its own review threads.** When it confirms in
+  natural language, `github-pr-fixer` must explicitly call the
+  `resolveReviewThread` GraphQL mutation on each confirmed thread.
+- **Two-`fail-label` stop in `gstack-full`.** If the same issue has been
+  picked up and failed twice, the orchestrator stops touching it and
+  surfaces it to the user.
+- **Never `max-per-cycle > 3`** in `gstack-full` without explicit user
+  consent; default is 1.
+- **Poll cadence floor (per user memory): 10 minutes.** This doc records
+  what the SKILL.md files currently say (60s for `gstack-gh` plan-approval,
+  5 min for `github-pr-fixer` reviewer watch). The user's
+  `feedback_poll_min_interval` memory overrides those to ≥ 600s; the skills
+  themselves have not yet been updated to match.
+- **Branch name is `feature/<N>`** exactly — no slug, no variation. This is
+  a load-bearing invariant used by the handoff comment and the
+  `Closes #<N>` binding.


### PR DESCRIPTION
## Summary

- Adds `docs/quality/PRE-1.0-CHECKPOINT.md` — a written technical review of the current codebase ahead of a 1.0 release cut.
- Covers architecture compliance, design, testing, code quality, operational & security posture, docs, and release readiness.
- Report-only: no behaviour changes, no refactors, no test additions. Every finding is a candidate for a follow-up issue.

## Highlights

- ✅ 323/323 tests pass, lint clean, structure check clean, 0 circular deps, 0 dead code, 0 TODO/FIXME/@ts-expect-error.
- ❌ **P0 blockers for 1.0** — §9.1 lists four: version drift (`package.json` stuck at `0.1.0-alpha.1` vs real tag `0.8.1`), missing `request-proxy` in `DOMAIN-BOUNDARIES.md` / `QUALITY-GRADES.md` (doc drift from #21), no CHANGELOG, and `registerExecuteRoutes` complexity (cc=21, 289 lines).
- ⚠️ **P1 items** — §9.2 lists six complexity/docs items (proxy auth, executeCommand nesting, createApp wiring, cli.ts split, API-key JSDoc, rate-limit audit).

## Test plan
- [ ] CI: lint + check:structure + build + tests all pass (report is a single markdown file)
- [ ] Review the P0 bucket in §9.1 and decide which land as follow-up issues vs in the 1.0 cut

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)