### PR TITLE
refactor(#32): flatten executeCommand nesting from 6 to ≤3

### DIFF
--- a/server/src/domains/command-gateway/service/execute_command.ts
+++ b/server/src/domains/command-gateway/service/execute_command.ts
@@ -1,6 +1,6 @@
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import type { AliasesConfig, ExecutionResult } from '../types/command_types.js';
-import { resolveAlias } from './resolve_alias.js';
+import { resolveAlias, type ResolvedAlias } from './resolve_alias.js';
 import { createChildLogger } from '../../../lib/logger.js';
 
 const log = createChildLogger('executor');
@@ -19,7 +19,7 @@ export interface ExecuteOptions {
 }
 
 export async function executeCommand(options: ExecuteOptions): Promise<ExecutionResult> {
-  const { command, requestId, cwd, timeoutMs, maxOutputBytes, maxConcurrent, abortSignal, aliases } = options;
+  const { command, requestId, cwd, maxConcurrent, aliases } = options;
 
   if (activeExecutions >= maxConcurrent) {
     log.warn({ requestId, active: activeExecutions, max: maxConcurrent }, 'Max concurrent executions reached');
@@ -39,119 +39,142 @@ export async function executeCommand(options: ExecuteOptions): Promise<Execution
   );
 
   try {
-    return await new Promise<ExecutionResult>((resolve) => {
-      // This is a command gateway that intentionally executes user-supplied
-      // commands. Access is gated by API-key auth and configurable command
-      // rules (allow/deny lists). The spawn call below is by design.
-      const child = resolved
-        ? spawn(resolved.spawnCommand, resolved.spawnArgs, { cwd: resolved.cwd, detached: true })
-        : spawn(command, { shell: true, cwd: cwd ?? process.cwd(), detached: true }); // NOSONAR -- intentional: this gateway executes user-supplied commands gated by API-key auth and command rules
-
-      let stdout = '';
-      let stderr = '';
-      let outputBytes = 0;
-      let killed = false;
-
-      const timer = setTimeout(() => {
-        killed = true;
-        try { process.kill(-child.pid!, 'SIGKILL'); } catch { child.kill('SIGKILL'); }
-        log.warn({ requestId, timeoutMs }, 'Command timed out');
-      }, timeoutMs);
-
-      const onAbort = () => {
-        killed = true;
-        try { process.kill(-child.pid!, 'SIGKILL'); } catch { child.kill('SIGKILL'); }
-        clearTimeout(timer);
-        log.info({ requestId }, 'Command aborted (client disconnected)');
-      };
-
-      if (abortSignal) {
-        if (abortSignal.aborted) {
-          try { process.kill(-child.pid!, 'SIGKILL'); } catch { child.kill('SIGKILL'); }
-          clearTimeout(timer);
-          resolve({ requestId, status: 'failed', error: 'Request aborted' });
-          return;
-        }
-        abortSignal.addEventListener('abort', onAbort, { once: true });
-      }
-
-      child.stdout.on('data', (chunk: Buffer) => {
-        outputBytes += chunk.length;
-        if (outputBytes <= maxOutputBytes) {
-          stdout += chunk.toString();
-        } else if (!killed) {
-          killed = true;
-          try { process.kill(-child.pid!, 'SIGKILL'); } catch { child.kill('SIGKILL'); }
-          clearTimeout(timer);
-          log.warn({ requestId, outputBytes, maxOutputBytes }, 'Output buffer exceeded');
-        }
-      });
-
-      child.stderr.on('data', (chunk: Buffer) => {
-        outputBytes += chunk.length;
-        if (outputBytes <= maxOutputBytes) {
-          stderr += chunk.toString();
-        }
-      });
-
-      child.on('close', (code) => {
-        clearTimeout(timer);
-        if (abortSignal) {
-          abortSignal.removeEventListener('abort', onAbort);
-        }
-
-        const durationMs = Date.now() - startTime;
-
-        if (killed && outputBytes > maxOutputBytes) {
-          resolve({
-            requestId,
-            status: 'failed',
-            stdout: stdout.slice(0, maxOutputBytes),
-            stderr,
-            durationMs,
-            error: `Output exceeded ${maxOutputBytes} bytes limit`,
-          });
-          return;
-        }
-
-        if (killed) {
-          resolve({
-            requestId,
-            status: 'timed_out',
-            stdout,
-            stderr,
-            durationMs,
-            error: `Command timed out after ${timeoutMs}ms`,
-          });
-          return;
-        }
-
-        resolve({
-          requestId,
-          status: code === 0 ? 'completed' : 'failed',
-          exitCode: code ?? undefined,
-          stdout,
-          stderr,
-          durationMs,
-        });
-
-        log.info({ requestId, exitCode: code, durationMs }, 'Command completed');
-      });
-
-      child.on('error', (err) => {
-        clearTimeout(timer);
-        if (abortSignal) {
-          abortSignal.removeEventListener('abort', onAbort);
-        }
-        resolve({
-          requestId,
-          status: 'failed',
-          error: `Failed to execute: ${err.message}`,
-          durationMs: Date.now() - startTime,
-        });
-      });
-    });
+    return await runChildProcess(options, resolved, startTime);
   } finally {
     activeExecutions--;
   }
+}
+
+function spawnChild(options: ExecuteOptions, resolved: ResolvedAlias | null): ChildProcessWithoutNullStreams {
+  // This is a command gateway that intentionally executes user-supplied
+  // commands. Access is gated by API-key auth and configurable command
+  // rules (allow/deny lists). The spawn call below is by design.
+  if (resolved) {
+    return spawn(resolved.spawnCommand, resolved.spawnArgs, { cwd: resolved.cwd, detached: true });
+  }
+  return spawn(options.command, { shell: true, cwd: options.cwd ?? process.cwd(), detached: true }); // NOSONAR -- intentional: this gateway executes user-supplied commands gated by API-key auth and command rules
+}
+
+function killChildTree(child: ChildProcess): void {
+  try {
+    process.kill(-child.pid!, 'SIGKILL');
+  } catch {
+    child.kill('SIGKILL');
+  }
+}
+
+function runChildProcess(
+  options: ExecuteOptions,
+  resolved: ResolvedAlias | null,
+  startTime: number,
+): Promise<ExecutionResult> {
+  const { requestId, timeoutMs, maxOutputBytes, abortSignal } = options;
+
+  return new Promise<ExecutionResult>((resolve) => {
+    const child = spawnChild(options, resolved);
+
+    let stdout = '';
+    let stderr = '';
+    let outputBytes = 0;
+    let killed = false;
+
+    const timer = setTimeout(() => {
+      killed = true;
+      killChildTree(child);
+      log.warn({ requestId, timeoutMs }, 'Command timed out');
+    }, timeoutMs);
+
+    const onAbort = () => {
+      killed = true;
+      killChildTree(child);
+      clearTimeout(timer);
+      log.info({ requestId }, 'Command aborted (client disconnected)');
+    };
+
+    if (abortSignal?.aborted) {
+      killChildTree(child);
+      clearTimeout(timer);
+      resolve({ requestId, status: 'failed', error: 'Request aborted' });
+      return;
+    }
+    abortSignal?.addEventListener('abort', onAbort, { once: true });
+
+    const handleStdoutChunk = (chunk: Buffer) => {
+      outputBytes += chunk.length;
+      if (outputBytes <= maxOutputBytes) {
+        stdout += chunk.toString();
+        return;
+      }
+      if (killed) return;
+      killed = true;
+      killChildTree(child);
+      clearTimeout(timer);
+      log.warn({ requestId, outputBytes, maxOutputBytes }, 'Output buffer exceeded');
+    };
+
+    const handleStderrChunk = (chunk: Buffer) => {
+      outputBytes += chunk.length;
+      if (outputBytes <= maxOutputBytes) {
+        stderr += chunk.toString();
+      }
+    };
+
+    const handleClose = (code: number | null) => {
+      clearTimeout(timer);
+      abortSignal?.removeEventListener('abort', onAbort);
+
+      const durationMs = Date.now() - startTime;
+
+      if (killed && outputBytes > maxOutputBytes) {
+        resolve({
+          requestId,
+          status: 'failed',
+          stdout: stdout.slice(0, maxOutputBytes),
+          stderr,
+          durationMs,
+          error: `Output exceeded ${maxOutputBytes} bytes limit`,
+        });
+        return;
+      }
+
+      if (killed) {
+        resolve({
+          requestId,
+          status: 'timed_out',
+          stdout,
+          stderr,
+          durationMs,
+          error: `Command timed out after ${timeoutMs}ms`,
+        });
+        return;
+      }
+
+      resolve({
+        requestId,
+        status: code === 0 ? 'completed' : 'failed',
+        exitCode: code ?? undefined,
+        stdout,
+        stderr,
+        durationMs,
+      });
+
+      log.info({ requestId, exitCode: code, durationMs }, 'Command completed');
+    };
+
+    const handleError = (err: Error) => {
+      clearTimeout(timer);
+      abortSignal?.removeEventListener('abort', onAbort);
+      resolve({
+        requestId,
+        status: 'failed',
+        error: `Failed to execute: ${err.message}`,
+        durationMs: Date.now() - startTime,
+      });
+    };
+
+    child.stdout.on('data', handleStdoutChunk);
+    child.stderr.on('data', handleStderrChunk);
+    child.on('close', handleClose);
+    child.on('error', handleError);
+  });
 }


### PR DESCRIPTION
## Summary
- Refactor `executeCommand` in `server/src/domains/command-gateway/service/execute_command.ts` to flatten nesting from `max_nesting=6` to ≤3.
- Extract three module-scoped helpers: `spawnChild` (the `spawn` call + NOSONAR rationale), `killChildTree` (the try/catch kill pattern used four times), and `runChildProcess` (the Promise body).
- Each event handler is a named inner function in `runChildProcess` with early-return guard clauses — no deeply nested `if/else/try` chains.
- Public signature (`executeCommand(options: ExecuteOptions): Promise<ExecutionResult>`), log lines, error strings, and the concurrency-accounting contract are all unchanged. Pure behaviour-preserving refactor per the issue body.
- Resolves pre-1.0 checkpoint Finding C3.

Closes #32

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 323/323 passing (including the existing `execute_command.test.ts` regression suite)
- [x] `npm run build` — `check:structure` + `tsc -p tsconfig.server.json`, both clean

## Note
This PR modifies `.ts` source, so CI will run normally (not `paths-ignore`'d).
