### PR TITLE
docs(#35): add JSDoc with threat model to api-key-store

### DIFF
--- a/server/src/domains/command-gateway/repository/api_key_store.ts
+++ b/server/src/domains/command-gateway/repository/api_key_store.ts
@@ -24,10 +24,25 @@ function isApiKeysConfig(data: unknown): data is ApiKeysConfig {
   return d.keys.every(isValidKeyEntry);
 }
 
+/**
+ * Derive a 64-byte scrypt hash of `key` with `salt`, hex-encoded.
+ *
+ * Defends against: offline brute-force of a leaked `keyHash` (scrypt is memory-hard).
+ * Does NOT defend against: leaking both `keyHash` AND `salt` together, online
+ * guessing (that is the job of rate-limiting at the HTTP boundary), or disclosure
+ * of the raw `key` — once the key is out, the hash is moot.
+ */
 export function hashApiKey(key: string, salt: string): string {
   return scryptSync(key, salt, 64).toString('hex');
 }
 
+/**
+ * Generate a fresh API key + per-key salt + scrypt hash.
+ *
+ * The raw `key` exists only in memory at generation time and is never persisted;
+ * only `salt` and `keyHash` are stored. Callers are responsible for delivering the
+ * raw key to the operator over a secure channel (the CLI writes it once to stdout).
+ */
 export function generateApiKey(): { key: string; salt: string; keyHash: string } {
   const key = 'luc_' + randomBytes(24).toString('hex');
   const salt = randomBytes(16).toString('hex');
@@ -35,6 +50,13 @@ export function generateApiKey(): { key: string; salt: string; keyHash: string }
   return { key, salt, keyHash };
 }
 
+/**
+ * Generate a fresh admin bearer secret + salt + scrypt hash.
+ *
+ * Same shape as {@link generateApiKey} but with an `luc_admin_` prefix. The admin
+ * secret gates the `/admin/*` surface (approval UI, SSE stream); it is NOT a valid
+ * API-key for `/api/v1/execute`. Do not interchange the two.
+ */
 export function generateAdminSecret(): { secret: string; salt: string; secretHash: string } {
   const secret = 'luc_admin_' + randomBytes(24).toString('hex');
   const salt = randomBytes(16).toString('hex');
@@ -42,11 +64,22 @@ export function generateAdminSecret(): { secret: string; salt: string; secretHas
   return { secret, salt, secretHash };
 }
 
+/** Façade over the on-disk api-keys config; exposes lookup + hot reload. */
 export interface ApiKeyStore {
+  /** Constant-time lookup by raw key. Returns `undefined` for inactive or unknown keys. Never logs the raw key. */
   findByKey(rawKey: string): ApiKeyConfig | undefined;
+  /** Re-read the backing config file. Does not lock; the caller is responsible for serialisation. */
   reload(): void;
 }
 
+/**
+ * Construct an {@link ApiKeyStore} reading from `configPath`.
+ *
+ * `findByKey` iterates only `active: true` entries and compares with `timingSafeEqual`
+ * over equal-length buffers, so lookup time does not leak which stored hash matched.
+ * Does NOT defend against: a compromised config file (the salt + keyHash are enough
+ * to run offline scrypt cracking) or a process-memory read during `hashApiKey`.
+ */
 export function createApiKeyStore(configPath: string): ApiKeyStore {
   let config: ApiKeysConfig;
 


### PR DESCRIPTION
## Summary
- Add JSDoc to every exported symbol of `server/src/domains/command-gateway/repository/api_key_store.ts` with explicit threat-model notes: `hashApiKey`, `generateApiKey`, `generateAdminSecret`, `createApiKeyStore`, `ApiKeyStore` (plus its `findByKey`/`reload` methods).
- Each doc states what the primitive defends against (offline hash-cracking via scrypt memory-hardness; constant-time lookup via `timingSafeEqual`) and what it explicitly does NOT defend against (compromised config file, process-memory read, leaked raw key).
- Comment-only change; zero runtime impact.
- Resolves pre-1.0 checkpoint Finding S2.

Closes #35

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 323/323 passing
- [x] `npm run build` — `check:structure` + `tsc -p tsconfig.server.json`, both clean
