### PR TITLE
refactor(#34): split cli.ts and register_execute_routes.ts under 300 lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Target content for 1.0 (tracked in [`docs/quality/PRE-1.0-CHECKPOINT.md`](docs/q
 - Stabilise the public HTTP surface on `command-gateway` and `request-proxy`.
 - Lock the layered dependency direction (Types → Config → Repository → Service → Runtime → UI/API) as a hard CI invariant.
 
+## [0.8.10] — 2026-04-21
+
+### Changed
+- `server/src/cli.ts` (350 → 63 lines): subcommand bodies moved into `server/src/cli/` (`print_help`, `init_config`, `run_log`, `run_stats`, `run_pair`, `run_server`) with a small `args.ts` helper. `cli.ts` is now a thin dispatcher.
+- `server/src/domains/command-gateway/api/register_execute_routes.ts` (353 → 188 lines): the `always_approve` / cached-approval execute-and-audit pattern is hoisted into `service/execute_and_audit.ts`; the manual-approve try/catch is hoisted into `service/handle_manual_approval.ts`.
+- Behaviour-preserving: audit shape, HTTP status codes, ADR-009 alias-bypass ordering, abort-on-disconnect semantics, and rate-limiter placement all unchanged. All 329 tests still pass (#34, #45).
+
 ## [0.8.9] — 2026-04-21
 
 ### Changed

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -1,279 +1,14 @@
 #!/usr/bin/env node
 
-import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { resolve, join } from 'node:path';
-import { createInterface } from 'node:readline/promises';
-import { createApp } from './create_app.js';
-import { generateApiKey, generateAdminSecret } from './domains/command-gateway/repository/api_key_store.js';
-import { getDatabase } from './domains/command-gateway/repository/database.js';
-import { createAuditLog } from './domains/command-gateway/repository/audit_log.js';
-import { createApprovalStore } from './domains/command-gateway/repository/approval_store.js';
-import { runTelegramPairing } from './domains/command-gateway/service/telegram_pairing.js';
-import { redactApiKeyName } from './domains/command-gateway/service/redact_api_key_name.js';
-import { getTelegramToken } from './domains/command-gateway/config/gateway_config.js';
-import { updateJsonConfig } from './lib/json_config_writer.js';
-import { logger } from './lib/logger.js';
-import type { PairingIO } from './domains/command-gateway/service/telegram_pairing.js';
+import { getArgValue } from './cli/args.js';
+import { printHelp } from './cli/print_help.js';
+import { initConfig } from './cli/init_config.js';
+import { runLog } from './cli/run_log.js';
+import { runStats } from './cli/run_stats.js';
+import { runPair } from './cli/run_pair.js';
+import { runServer } from './cli/run_server.js';
 
 const args = process.argv.slice(2);
-
-function printHelp() {
-  console.log(`
-lucifer-gate - AI Agent Command Firewall
-
-Usage:
-  lucifer-gate start [options]        Start the server (explicit form)
-  lucifer-gate [options]              Start the server (implicit, same as 'start')
-  lucifer-gate --init [dir]           Generate starter config files
-  lucifer-gate pair [--config <path>] Pair a Telegram chat for approvals
-  lucifer-gate log [--limit N]        Query audit log
-  lucifer-gate stats                  Show approval statistics
-
-Server options:
-  --config <path>    Path to lucifer.json (default: ./config/lucifer.json)
-  --port <number>    Server port (default: 3001, or PORT env var)
-  --data-dir <path>  Directory for SQLite database (default: ./data)
-  --auto-approve     Auto-approve all commands (dev mode, no Telegram needed)
-  --help             Show this help
-
-Environment variables:
-  LUCIFER_TELEGRAM_TOKEN   Telegram bot token (required for production)
-  LUCIFER_TELEGRAM_CHAT_ID Telegram chat ID for approvals (or use 'pair' command)
-  PORT                     Server port (default: 3001)
-  LOG_LEVEL                Log level: debug, info, warn, error (default: debug / info in production)
-`);
-}
-
-function initConfig(targetDir: string) {
-  const configDir = resolve(targetDir, 'config');
-  const dataDir = resolve(targetDir, 'data');
-  mkdirSync(configDir, { recursive: true });
-  mkdirSync(dataDir, { recursive: true });
-
-  const luciferJsonPath = join(configDir, 'lucifer.json');
-  const apiKeysPath = join(configDir, 'api-keys.json');
-  const commandRulesPath = join(configDir, 'command-rules.json');
-  const proxyConfigPath = join(configDir, 'proxy-config.json');
-
-  if (existsSync(luciferJsonPath)) {
-    console.log(`Config already exists: ${luciferJsonPath}`);
-    console.log('Delete it first if you want to regenerate.');
-    return;
-  }
-
-  const { key, salt, keyHash } = generateApiKey();
-  const { secret: adminSecret, salt: adminSalt, secretHash: adminHash } = generateAdminSecret();
-
-  writeFileSync(luciferJsonPath, JSON.stringify({
-    port: 3001,
-    adminSecretHash: adminHash,
-    adminSecretSalt: adminSalt,
-    approvalTimeoutSeconds: 300,
-    executionTimeoutSeconds: 120,
-    maxConcurrentExecutions: 5,
-    maxOutputBytes: 10485760,
-    rateLimitPerMinute: 10,
-    onApprovalTimeout: 'deny',
-    dataDir: '../data',
-    logFile: 'lucifer.log',
-  }, null, 2) + '\n');
-
-  writeFileSync(apiKeysPath, JSON.stringify({
-    keys: [{
-      id: crypto.randomUUID(),
-      name: 'default',
-      keyHash,
-      salt,
-      allowedIps: [],
-      createdAt: new Date().toISOString(),
-      active: true,
-    }],
-  }, null, 2) + '\n');
-
-  writeFileSync(commandRulesPath, JSON.stringify({
-    rules: [
-      { prefix: 'echo ', action: 'always_approve' },
-      { prefix: 'git status', action: 'always_approve' },
-      { prefix: 'git pull', action: 'manual_approve' },
-      { prefix: 'git push', action: 'manual_approve' },
-      { prefix: 'npm test', action: 'always_approve' },
-      { prefix: 'npm run', action: 'manual_approve' },
-      { prefix: 'rm ', action: 'always_deny' },
-    ],
-    defaultAction: 'always_deny',
-  }, null, 2) + '\n');
-
-  writeFileSync(proxyConfigPath, JSON.stringify({
-    proxies: [],
-  }, null, 2) + '\n');
-
-  console.log('Config files generated:');
-  console.log(`  ${luciferJsonPath}`);
-  console.log(`  ${apiKeysPath}`);
-  console.log(`  ${commandRulesPath}`);
-  console.log(`  ${proxyConfigPath}`);
-  console.log('');
-  console.log('Your API key (save this, it cannot be recovered):');
-  console.log(`  ${key}`);
-  console.log('');
-  console.log('Your admin secret for the web approval UI (save this, it cannot be recovered):');
-  console.log(`  ${adminSecret}`);
-  console.log('');
-  console.log('Quick start:');
-  console.log('  # Dev mode (no Telegram needed):');
-  console.log(`  LUCIFER_TELEGRAM_TOKEN=skip lucifer-gate --config ${luciferJsonPath} --auto-approve`);
-  console.log('');
-  console.log('  # Production — pair your Telegram chat first:');
-  console.log(`  LUCIFER_TELEGRAM_TOKEN=your_token lucifer-gate pair --config ${luciferJsonPath}`);
-  console.log('');
-  console.log('  # Then start the server:');
-  console.log(`  LUCIFER_TELEGRAM_TOKEN=your_token lucifer-gate --config ${luciferJsonPath}`);
-}
-
-async function runLog(limit: number) {
-  const dataDir = getArgValue('--data-dir') ?? './data';
-  const db = getDatabase(dataDir);
-  const auditLog = createAuditLog(db);
-  const entries = auditLog.query(limit);
-
-  if (entries.length === 0) {
-    console.log('No audit log entries found.');
-    return;
-  }
-
-  const reversed = [...entries].reverse();
-  for (const entry of reversed) {
-    const time = entry.ts.replace('T', ' ').replace(/\.\d+Z$/, 'Z');
-    const parts = [time, entry.type.toUpperCase().padEnd(16)];
-    if (entry.command) parts.push(entry.command);
-    if (entry.apiKeyName) parts.push(`key=${redactApiKeyName(entry.apiKeyName)}`);
-    if (entry.exitCode !== undefined && entry.exitCode !== null) parts.push(`exit=${entry.exitCode}`);
-    if (entry.durationMs !== undefined && entry.durationMs !== null) parts.push(`${entry.durationMs}ms`);
-    if (entry.error) parts.push(`error: ${entry.error}`);
-    console.log(parts.join('  '));
-  }
-}
-
-async function runStats() {
-  const dataDir = getArgValue('--data-dir') ?? './data';
-  const db = getDatabase(dataDir);
-  const auditLog = createAuditLog(db);
-  const approvalStore = createApprovalStore(db);
-
-  const allEntries = auditLog.query(10000);
-  const requests = allEntries.filter(e => e.type === 'request');
-  const approvals = allEntries.filter(e => e.type === 'approved');
-  const denials = allEntries.filter(e => e.type === 'denied');
-  const executions = allEntries.filter(e => e.type === 'executed');
-
-  const activeApprovals = approvalStore.listAll(10000);
-  const expired = activeApprovals.filter(a => a.expiresAt && new Date(a.expiresAt) < new Date());
-
-  console.log('Lucifer Stats');
-  console.log('=============');
-  console.log(`Total requests:     ${requests.length}`);
-  console.log(`Approved:           ${approvals.length}`);
-  console.log(`Denied:             ${denials.length}`);
-  console.log(`Executed:           ${executions.length}`);
-  console.log(`Active approvals:   ${activeApprovals.length - expired.length}`);
-  console.log(`Expired approvals:  ${expired.length}`);
-
-  if (executions.length > 0) {
-    const durations = executions.filter(e => e.durationMs != null).map(e => e.durationMs!);
-    if (durations.length > 0) {
-      const avg = Math.round(durations.reduce((a, b) => a + b, 0) / durations.length);
-      const max = Math.max(...durations);
-      console.log(`Avg exec time:      ${avg}ms`);
-      console.log(`Max exec time:      ${max}ms`);
-    }
-  }
-
-  // Top commands
-  const cmdCounts = new Map<string, number>();
-  for (const r of requests) {
-    if (r.command) {
-      const cmd = r.command.split(/\s+/).slice(0, 2).join(' ');
-      cmdCounts.set(cmd, (cmdCounts.get(cmd) ?? 0) + 1);
-    }
-  }
-  const topCmds = [...cmdCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
-  if (topCmds.length > 0) {
-    console.log('\nTop commands:');
-    for (const [cmd, count] of topCmds) {
-      console.log(`  ${count.toString().padStart(5)}  ${cmd}`);
-    }
-  }
-}
-
-function createReadlinePairingIO(): PairingIO & { close(): void } {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-
-  return {
-    print(msg: string) {
-      console.log(msg);
-    },
-
-    async choose(prompt: string, options: string[]): Promise<number> {
-      console.log(`\n${prompt}`);
-      for (let i = 0; i < options.length; i++) {
-        console.log(`  ${i + 1}. ${options[i]}`);
-      }
-
-      while (true) {
-        const answer = await rl.question(`\nEnter number (1-${options.length}): `);
-        const num = Number.parseInt(answer.trim(), 10);
-        if (num >= 1 && num <= options.length) return num - 1;
-        console.log(`Please enter a number between 1 and ${options.length}.`);
-      }
-    },
-
-    async confirm(prompt: string): Promise<boolean> {
-      const answer = await rl.question(`${prompt} [y/N] `);
-      return /^y(es)?$/i.test(answer.trim());
-    },
-
-    async prompt(msg: string): Promise<string> {
-      return rl.question(`${msg} `);
-    },
-
-    close() {
-      rl.close();
-    },
-  };
-}
-
-async function runPair() {
-  const configPath = resolve(getArgValue('--config') ?? './config/lucifer.json');
-
-  let token: string;
-  try {
-    token = getTelegramToken();
-  } catch {
-    console.error(
-      'LUCIFER_TELEGRAM_TOKEN environment variable is required for pairing.\n' +
-      'Create a bot via @BotFather on Telegram and set the token:\n\n' +
-      '  LUCIFER_TELEGRAM_TOKEN=your_token lucifer-gate pair',
-    );
-    process.exit(1);
-  }
-
-  const io = createReadlinePairingIO();
-  try {
-    const result = await runTelegramPairing(token, io, { waitForChats: true });
-    updateJsonConfig(configPath, { telegramChatId: result.chatId });
-    console.log(`\nChat ID ${result.chatId} saved to ${configPath}`);
-    console.log('You can now start Lucifer without LUCIFER_TELEGRAM_CHAT_ID:');
-    console.log(`\n  LUCIFER_TELEGRAM_TOKEN=your_token lucifer-gate start --config ${configPath}`);
-  } finally {
-    io.close();
-  }
-}
-
-function getArgValue(flag: string): string | undefined {
-  const idx = args.indexOf(flag);
-  if (idx === -1 || idx >= args.length - 1) return undefined;
-  return args[idx + 1];
-}
 
 async function main() {
   if (args.includes('--help') || args.includes('-h')) {
@@ -288,18 +23,18 @@ async function main() {
   }
 
   if (args[0] === 'pair') {
-    await runPair();
+    await runPair(getArgValue(args, '--config') ?? './config/lucifer.json');
     process.exit(0);
   }
 
   if (args[0] === 'log') {
-    const limitStr = getArgValue('--limit');
-    await runLog(limitStr ? parseInt(limitStr, 10) : 50);
+    const limitStr = getArgValue(args, '--limit');
+    await runLog(limitStr ? parseInt(limitStr, 10) : 50, getArgValue(args, '--data-dir') ?? './data');
     process.exit(0);
   }
 
   if (args[0] === 'stats') {
-    await runStats();
+    await runStats(getArgValue(args, '--data-dir') ?? './data');
     process.exit(0);
   }
 
@@ -313,33 +48,11 @@ async function main() {
     process.exit(1);
   }
 
-  const configPath = getArgValue('--config') ?? './config/lucifer.json';
-  const port = getArgValue('--port');
-  const autoApprove = args.includes('--auto-approve');
-
-  if (port) {
-    process.env.PORT = port;
-  }
-
-  const { app, config, start, stop } = createApp({
-    configPath,
-    autoApprove,
+  await runServer({
+    configPath: getArgValue(args, '--config') ?? './config/lucifer.json',
+    port: getArgValue(args, '--port'),
+    autoApprove: args.includes('--auto-approve'),
   });
-
-  const server = app.listen(config.port, async () => {
-    logger.info({ port: config.port, autoApprove }, 'Lucifer listening');
-    await start();
-  });
-
-  const shutdown = async () => {
-    logger.info('Shutting down');
-    await stop();
-    server.close();
-    process.exit(0);
-  };
-
-  process.on('SIGTERM', shutdown);
-  process.on('SIGINT', shutdown);
 }
 
 try {

--- a/server/src/cli/args.ts
+++ b/server/src/cli/args.ts
@@ -1,0 +1,5 @@
+export function getArgValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1 || idx >= args.length - 1) return undefined;
+  return args[idx + 1];
+}

--- a/server/src/cli/init_config.ts
+++ b/server/src/cli/init_config.ts
@@ -1,0 +1,89 @@
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { generateApiKey, generateAdminSecret } from '../domains/command-gateway/repository/api_key_store.js';
+
+export function initConfig(targetDir: string) {
+  const configDir = resolve(targetDir, 'config');
+  const dataDir = resolve(targetDir, 'data');
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
+
+  const luciferJsonPath = join(configDir, 'lucifer.json');
+  const apiKeysPath = join(configDir, 'api-keys.json');
+  const commandRulesPath = join(configDir, 'command-rules.json');
+  const proxyConfigPath = join(configDir, 'proxy-config.json');
+
+  if (existsSync(luciferJsonPath)) {
+    console.log(`Config already exists: ${luciferJsonPath}`);
+    console.log('Delete it first if you want to regenerate.');
+    return;
+  }
+
+  const { key, salt, keyHash } = generateApiKey();
+  const { secret: adminSecret, salt: adminSalt, secretHash: adminHash } = generateAdminSecret();
+
+  writeFileSync(luciferJsonPath, JSON.stringify({
+    port: 3001,
+    adminSecretHash: adminHash,
+    adminSecretSalt: adminSalt,
+    approvalTimeoutSeconds: 300,
+    executionTimeoutSeconds: 120,
+    maxConcurrentExecutions: 5,
+    maxOutputBytes: 10485760,
+    rateLimitPerMinute: 10,
+    onApprovalTimeout: 'deny',
+    dataDir: '../data',
+    logFile: 'lucifer.log',
+  }, null, 2) + '\n');
+
+  writeFileSync(apiKeysPath, JSON.stringify({
+    keys: [{
+      id: crypto.randomUUID(),
+      name: 'default',
+      keyHash,
+      salt,
+      allowedIps: [],
+      createdAt: new Date().toISOString(),
+      active: true,
+    }],
+  }, null, 2) + '\n');
+
+  writeFileSync(commandRulesPath, JSON.stringify({
+    rules: [
+      { prefix: 'echo ', action: 'always_approve' },
+      { prefix: 'git status', action: 'always_approve' },
+      { prefix: 'git pull', action: 'manual_approve' },
+      { prefix: 'git push', action: 'manual_approve' },
+      { prefix: 'npm test', action: 'always_approve' },
+      { prefix: 'npm run', action: 'manual_approve' },
+      { prefix: 'rm ', action: 'always_deny' },
+    ],
+    defaultAction: 'always_deny',
+  }, null, 2) + '\n');
+
+  writeFileSync(proxyConfigPath, JSON.stringify({
+    proxies: [],
+  }, null, 2) + '\n');
+
+  console.log('Config files generated:');
+  console.log(`  ${luciferJsonPath}`);
+  console.log(`  ${apiKeysPath}`);
+  console.log(`  ${commandRulesPath}`);
+  console.log(`  ${proxyConfigPath}`);
+  console.log('');
+  console.log('Your API key (save this, it cannot be recovered):');
+  console.log(`  ${key}`);
+  console.log('');
+  console.log('Your admin secret for the web approval UI (save this, it cannot be recovered):');
+  console.log(`  ${adminSecret}`);
+  console.log('');
+  console.log('Quick start:');
+  console.log('  # Dev mode (no Telegram needed):');
+  console.log(`  LUCIFER_TELEGRAM_TOKEN=skip lucifer-gate --config ${luciferJsonPath} --auto-approve`);
+  console.log('');
+  console.log('  # Production — pair your Telegram chat first:');
+  console.log(`  LUCIFER_TELEGRAM_TOKEN=your_token lucifer-gate pair --config ${luciferJsonPath}`);
+  console.log('');
+  console.log('  # Then start the server:');
+  console.log(`  LUCIFER_TELEGRAM_TOKEN=your_token lucifer-gate --config ${luciferJsonPath}`);
+}

--- a/server/src/cli/print_help.ts
+++ b/server/src/cli/print_help.ts
@@ -1,0 +1,26 @@
+export function printHelp() {
+  console.log(`
+lucifer-gate - AI Agent Command Firewall
+
+Usage:
+  lucifer-gate start [options]        Start the server (explicit form)
+  lucifer-gate [options]              Start the server (implicit, same as 'start')
+  lucifer-gate --init [dir]           Generate starter config files
+  lucifer-gate pair [--config <path>] Pair a Telegram chat for approvals
+  lucifer-gate log [--limit N]        Query audit log
+  lucifer-gate stats                  Show approval statistics
+
+Server options:
+  --config <path>    Path to lucifer.json (default: ./config/lucifer.json)
+  --port <number>    Server port (default: 3001, or PORT env var)
+  --data-dir <path>  Directory for SQLite database (default: ./data)
+  --auto-approve     Auto-approve all commands (dev mode, no Telegram needed)
+  --help             Show this help
+
+Environment variables:
+  LUCIFER_TELEGRAM_TOKEN   Telegram bot token (required for production)
+  LUCIFER_TELEGRAM_CHAT_ID Telegram chat ID for approvals (or use 'pair' command)
+  PORT                     Server port (default: 3001)
+  LOG_LEVEL                Log level: debug, info, warn, error (default: debug / info in production)
+`);
+}

--- a/server/src/cli/run_log.ts
+++ b/server/src/cli/run_log.ts
@@ -1,0 +1,26 @@
+import { getDatabase } from '../domains/command-gateway/repository/database.js';
+import { createAuditLog } from '../domains/command-gateway/repository/audit_log.js';
+import { redactApiKeyName } from '../domains/command-gateway/service/redact_api_key_name.js';
+
+export async function runLog(limit: number, dataDir: string) {
+  const db = getDatabase(dataDir);
+  const auditLog = createAuditLog(db);
+  const entries = auditLog.query(limit);
+
+  if (entries.length === 0) {
+    console.log('No audit log entries found.');
+    return;
+  }
+
+  const reversed = [...entries].reverse();
+  for (const entry of reversed) {
+    const time = entry.ts.replace('T', ' ').replace(/\.\d+Z$/, 'Z');
+    const parts = [time, entry.type.toUpperCase().padEnd(16)];
+    if (entry.command) parts.push(entry.command);
+    if (entry.apiKeyName) parts.push(`key=${redactApiKeyName(entry.apiKeyName)}`);
+    if (entry.exitCode !== undefined && entry.exitCode !== null) parts.push(`exit=${entry.exitCode}`);
+    if (entry.durationMs !== undefined && entry.durationMs !== null) parts.push(`${entry.durationMs}ms`);
+    if (entry.error) parts.push(`error: ${entry.error}`);
+    console.log(parts.join('  '));
+  }
+}

--- a/server/src/cli/run_pair.ts
+++ b/server/src/cli/run_pair.ts
@@ -1,0 +1,70 @@
+import { resolve } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import { runTelegramPairing } from '../domains/command-gateway/service/telegram_pairing.js';
+import { getTelegramToken } from '../domains/command-gateway/config/gateway_config.js';
+import { updateJsonConfig } from '../lib/json_config_writer.js';
+import type { PairingIO } from '../domains/command-gateway/service/telegram_pairing.js';
+
+function createReadlinePairingIO(): PairingIO & { close(): void } {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  return {
+    print(msg: string) {
+      console.log(msg);
+    },
+
+    async choose(prompt: string, options: string[]): Promise<number> {
+      console.log(`\n${prompt}`);
+      for (let i = 0; i < options.length; i++) {
+        console.log(`  ${i + 1}. ${options[i]}`);
+      }
+
+      while (true) {
+        const answer = await rl.question(`\nEnter number (1-${options.length}): `);
+        const num = Number.parseInt(answer.trim(), 10);
+        if (num >= 1 && num <= options.length) return num - 1;
+        console.log(`Please enter a number between 1 and ${options.length}.`);
+      }
+    },
+
+    async confirm(prompt: string): Promise<boolean> {
+      const answer = await rl.question(`${prompt} [y/N] `);
+      return /^y(es)?$/i.test(answer.trim());
+    },
+
+    async prompt(msg: string): Promise<string> {
+      return rl.question(`${msg} `);
+    },
+
+    close() {
+      rl.close();
+    },
+  };
+}
+
+export async function runPair(configPath: string) {
+  const resolvedConfigPath = resolve(configPath);
+
+  let token: string;
+  try {
+    token = getTelegramToken();
+  } catch {
+    console.error(
+      'LUCIFER_TELEGRAM_TOKEN environment variable is required for pairing.\n' +
+      'Create a bot via @BotFather on Telegram and set the token:\n\n' +
+      '  LUCIFER_TELEGRAM_TOKEN=your_token lucifer-gate pair',
+    );
+    process.exit(1);
+  }
+
+  const io = createReadlinePairingIO();
+  try {
+    const result = await runTelegramPairing(token, io, { waitForChats: true });
+    updateJsonConfig(resolvedConfigPath, { telegramChatId: result.chatId });
+    console.log(`\nChat ID ${result.chatId} saved to ${resolvedConfigPath}`);
+    console.log('You can now start Lucifer without LUCIFER_TELEGRAM_CHAT_ID:');
+    console.log(`\n  LUCIFER_TELEGRAM_TOKEN=your_token lucifer-gate start --config ${resolvedConfigPath}`);
+  } finally {
+    io.close();
+  }
+}

--- a/server/src/cli/run_server.ts
+++ b/server/src/cli/run_server.ts
@@ -1,0 +1,34 @@
+import { createApp } from '../create_app.js';
+import { logger } from '../lib/logger.js';
+
+export interface RunServerOptions {
+  configPath: string;
+  port?: string;
+  autoApprove: boolean;
+}
+
+export async function runServer(options: RunServerOptions) {
+  if (options.port) {
+    process.env.PORT = options.port;
+  }
+
+  const { app, config, start, stop } = createApp({
+    configPath: options.configPath,
+    autoApprove: options.autoApprove,
+  });
+
+  const server = app.listen(config.port, async () => {
+    logger.info({ port: config.port, autoApprove: options.autoApprove }, 'Lucifer listening');
+    await start();
+  });
+
+  const shutdown = async () => {
+    logger.info('Shutting down');
+    await stop();
+    server.close();
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}

--- a/server/src/cli/run_stats.ts
+++ b/server/src/cli/run_stats.ts
@@ -1,0 +1,53 @@
+import { getDatabase } from '../domains/command-gateway/repository/database.js';
+import { createAuditLog } from '../domains/command-gateway/repository/audit_log.js';
+import { createApprovalStore } from '../domains/command-gateway/repository/approval_store.js';
+
+export async function runStats(dataDir: string) {
+  const db = getDatabase(dataDir);
+  const auditLog = createAuditLog(db);
+  const approvalStore = createApprovalStore(db);
+
+  const allEntries = auditLog.query(10000);
+  const requests = allEntries.filter(e => e.type === 'request');
+  const approvals = allEntries.filter(e => e.type === 'approved');
+  const denials = allEntries.filter(e => e.type === 'denied');
+  const executions = allEntries.filter(e => e.type === 'executed');
+
+  const activeApprovals = approvalStore.listAll(10000);
+  const expired = activeApprovals.filter(a => a.expiresAt && new Date(a.expiresAt) < new Date());
+
+  console.log('Lucifer Stats');
+  console.log('=============');
+  console.log(`Total requests:     ${requests.length}`);
+  console.log(`Approved:           ${approvals.length}`);
+  console.log(`Denied:             ${denials.length}`);
+  console.log(`Executed:           ${executions.length}`);
+  console.log(`Active approvals:   ${activeApprovals.length - expired.length}`);
+  console.log(`Expired approvals:  ${expired.length}`);
+
+  if (executions.length > 0) {
+    const durations = executions.filter(e => e.durationMs != null).map(e => e.durationMs!);
+    if (durations.length > 0) {
+      const avg = Math.round(durations.reduce((a, b) => a + b, 0) / durations.length);
+      const max = Math.max(...durations);
+      console.log(`Avg exec time:      ${avg}ms`);
+      console.log(`Max exec time:      ${max}ms`);
+    }
+  }
+
+  // Top commands
+  const cmdCounts = new Map<string, number>();
+  for (const r of requests) {
+    if (r.command) {
+      const cmd = r.command.split(/\s+/).slice(0, 2).join(' ');
+      cmdCounts.set(cmd, (cmdCounts.get(cmd) ?? 0) + 1);
+    }
+  }
+  const topCmds = [...cmdCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10);
+  if (topCmds.length > 0) {
+    console.log('\nTop commands:');
+    for (const [cmd, count] of topCmds) {
+      console.log(`  ${count.toString().padStart(5)}  ${cmd}`);
+    }
+  }
+}

--- a/server/src/domains/command-gateway/api/register_execute_routes.ts
+++ b/server/src/domains/command-gateway/api/register_execute_routes.ts
@@ -2,16 +2,13 @@ import { randomUUID } from 'node:crypto';
 import type { Router, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
 import type {
-  ApprovalChannel, RequestStatus, ErrorResponse, LuciferConfig,
+  ApprovalChannel, ErrorResponse, LuciferConfig,
 } from '../types/command_types.js';
 import type { ApiKeyStore, CommandRulesStore, ApprovalStore, PendingRequestStore, AuditLog } from '../types/store_interfaces.js';
 import { authenticateRequest, createRateLimiter } from '../service/authenticate_request.js';
-import { analyzeCommandRisk } from '../service/analyze_command_risk.js';
-import { executeCommand } from '../service/execute_command.js';
+import { executeAndAudit } from '../service/execute_and_audit.js';
+import { handleManualApproval } from '../service/handle_manual_approval.js';
 import { findAliasArgsBypass, resolveAlias } from '../service/resolve_alias.js';
-import { createChildLogger } from '../../../lib/logger.js';
-
-const log = createChildLogger('routes');
 
 interface ValidationError {
   statusCode: number;
@@ -163,26 +160,7 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
 
     if (ruleMatch.action === 'always_approve') {
       auditLog.append({ ts: new Date().toISOString(), type: 'approved', requestId, command, duration: 'policy', ...aliasAudit });
-      const result = await executeCommand({
-        command,
-        requestId,
-        cwd,
-        timeoutMs: config.executionTimeoutSeconds * 1000,
-        maxOutputBytes: config.maxOutputBytes,
-        maxConcurrent: config.maxConcurrentExecutions,
-        aliases: config.aliases,
-      });
-      auditLog.append({
-        ts: new Date().toISOString(),
-        type: 'executed',
-        requestId,
-        command,
-        exitCode: result.exitCode,
-        durationMs: result.durationMs,
-        error: result.error,
-        ...aliasAudit,
-      });
-      res.json(result);
+      await executeAndAudit({ command, requestId, cwd, config, auditLog, aliasAudit, res });
       return;
     }
 
@@ -197,157 +175,14 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
         duration: 'cached',
         ...aliasAudit,
       });
-      const result = await executeCommand({
-        command,
-        requestId,
-        cwd,
-        timeoutMs: config.executionTimeoutSeconds * 1000,
-        maxOutputBytes: config.maxOutputBytes,
-        maxConcurrent: config.maxConcurrentExecutions,
-        aliases: config.aliases,
-      });
-      auditLog.append({
-        ts: new Date().toISOString(),
-        type: 'executed',
-        requestId,
-        command,
-        exitCode: result.exitCode,
-        durationMs: result.durationMs,
-        error: result.error,
-        ...aliasAudit,
-      });
-      res.json(result);
+      await executeAndAudit({ command, requestId, cwd, config, auditLog, aliasAudit, res });
       return;
     }
 
     // Need manual approval (Telegram / web admin)
-    const riskAnalysis = analyzeCommandRisk(command);
-    const abortController = new AbortController();
-
-    log.info({ requestId, command, ip }, 'Command requires manual approval, forwarding to approval channel');
-
-    // Reject an identical command from the same API key that is still
-    // awaiting an approval decision — two parallel prompts for the same
-    // command would confuse the human approver. The pendingStore entry is
-    // cleared as soon as a decision is reached (below), so this gate does
-    // NOT apply while an approved command is executing; a concurrent caller
-    // will fall through to the normal `findApproval` cached-approval path.
-    if (pendingStore.findByCommand(command, apiKeyName)) {
-      res.status(409).json({
-        code: 'DUPLICATE_IN_FLIGHT',
-        message: 'An identical command from this API key is already awaiting approval. Retry after it settles.',
-        retryable: true,
-      } satisfies ErrorResponse);
-      return;
-    }
-
-    try {
-      pendingStore.add({
-        requestId,
-        command,
-        apiKeyName,
-        ip,
-        createdAt: new Date().toISOString(),
-        resolve: () => {},
-        reject: () => {},
-        abortController,
-      });
-
-      // Abort execution if the client disconnects before we finish writing
-      // the response. `res.on('close')` fires for both premature disconnects
-      // and normal completion, so we gate on `res.writableEnded` to ignore
-      // the normal-completion case.
-      res.on('close', () => {
-        if (res.writableEnded) return;
-        abortController.abort();
-        pendingStore.remove(requestId);
-      });
-
-      const approvalResult = await Promise.race([
-        approvalChannel.requestApproval(command, apiKeyName, ip, requestId, riskAnalysis),
-        new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error('Approval timed out')), config.approvalTimeoutSeconds * 1000);
-        }),
-        // Bail out of the approval wait if the client disconnected. Otherwise
-        // the handler would continue awaiting the channel until either the
-        // approver acts or the approval timeout fires — orphaning work that
-        // nobody is listening for.
-        new Promise<never>((_, reject) => {
-          if (abortController.signal.aborted) {
-            reject(new Error('Request aborted'));
-            return;
-          }
-          abortController.signal.addEventListener(
-            'abort',
-            () => reject(new Error('Request aborted')),
-            { once: true },
-          );
-        }),
-      ]);
-
-      // Approval decision obtained — release the pending-store slot now so
-      // DUPLICATE_IN_FLIGHT only gates *awaiting-approval* duplicates and
-      // not in-flight execution. `release` (unlike `remove`) does not abort
-      // the live AbortController, which still guards the upcoming execution.
-      pendingStore.release(requestId);
-
-      if (approvalResult.decision === 'denied') {
-        res.status(403).json({
-          requestId,
-          status: 'denied' as RequestStatus,
-          code: 'DENIED',
-          message: 'Command was denied',
-          retryable: false,
-        });
-        return;
-      }
-
-      const result = await executeCommand({
-        command,
-        requestId,
-        cwd,
-        timeoutMs: config.executionTimeoutSeconds * 1000,
-        maxOutputBytes: config.maxOutputBytes,
-        maxConcurrent: config.maxConcurrentExecutions,
-        abortSignal: abortController.signal,
-        aliases: config.aliases,
-      });
-      auditLog.append({
-        ts: new Date().toISOString(),
-        type: 'executed',
-        requestId,
-        command,
-        exitCode: result.exitCode,
-        durationMs: result.durationMs,
-        error: result.error,
-        ...aliasAudit,
-      });
-      res.json(result);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      if (message.includes('aborted')) {
-        // Client disconnected before a decision landed. Ask the channel to
-        // clean up any bot message / admin queue entry. No response to send.
-        try { approvalChannel.cancel?.(requestId); } catch { /* best-effort */ }
-        log.info({ requestId }, 'Approval wait aborted by client disconnect');
-      } else if (message.includes('timed out')) {
-        res.status(408).json({
-          requestId,
-          status: 'timed_out' as RequestStatus,
-          code: 'APPROVAL_TIMEOUT',
-          message: 'Approval timed out. No response from approver.',
-          retryable: true,
-        });
-      } else {
-        res.status(503).json({
-          requestId,
-          code: 'APPROVAL_ERROR',
-          message: `Approval channel error: ${message}`,
-          retryable: true,
-        });
-      }
-    } finally {
-      pendingStore.remove(requestId);
-    }
+    await handleManualApproval({
+      command, requestId, apiKeyName, ip, cwd, config,
+      approvalChannel, pendingStore, auditLog, aliasAudit, res,
+    });
   });
 }

--- a/server/src/domains/command-gateway/service/execute_and_audit.ts
+++ b/server/src/domains/command-gateway/service/execute_and_audit.ts
@@ -1,0 +1,48 @@
+import type { Response } from 'express';
+import type { AliasType, LuciferConfig } from '../types/command_types.js';
+import type { AuditLog } from '../types/store_interfaces.js';
+import { executeCommand } from './execute_command.js';
+
+export type AliasAudit = { aliasPath?: string; aliasType?: AliasType };
+
+export interface ExecuteAndAuditArgs {
+  command: string;
+  requestId: string;
+  cwd: string | undefined;
+  config: LuciferConfig;
+  auditLog: AuditLog;
+  aliasAudit: AliasAudit;
+  abortSignal?: AbortSignal;
+  res: Response;
+}
+
+/**
+ * Runs `executeCommand` with config-derived options, writes the `executed`
+ * audit entry (carrying alias context when present), and returns the JSON
+ * response. Shared across the always_approve, cached-approval, and
+ * manual-approve branches so audit shape stays identical.
+ */
+export async function executeAndAudit(args: ExecuteAndAuditArgs): Promise<void> {
+  const { command, requestId, cwd, config, auditLog, aliasAudit, abortSignal, res } = args;
+  const result = await executeCommand({
+    command,
+    requestId,
+    cwd,
+    timeoutMs: config.executionTimeoutSeconds * 1000,
+    maxOutputBytes: config.maxOutputBytes,
+    maxConcurrent: config.maxConcurrentExecutions,
+    abortSignal,
+    aliases: config.aliases,
+  });
+  auditLog.append({
+    ts: new Date().toISOString(),
+    type: 'executed',
+    requestId,
+    command,
+    exitCode: result.exitCode,
+    durationMs: result.durationMs,
+    error: result.error,
+    ...aliasAudit,
+  });
+  res.json(result);
+}

--- a/server/src/domains/command-gateway/service/handle_manual_approval.ts
+++ b/server/src/domains/command-gateway/service/handle_manual_approval.ts
@@ -1,0 +1,148 @@
+import type { Response } from 'express';
+import type { ApprovalChannel, ErrorResponse, LuciferConfig, RequestStatus } from '../types/command_types.js';
+import type { AuditLog, PendingRequestStore } from '../types/store_interfaces.js';
+import { analyzeCommandRisk } from './analyze_command_risk.js';
+import { executeAndAudit, type AliasAudit } from './execute_and_audit.js';
+import { createChildLogger } from '../../../lib/logger.js';
+
+const log = createChildLogger('routes');
+
+export interface ManualApprovalArgs {
+  command: string;
+  requestId: string;
+  apiKeyName: string;
+  ip: string;
+  cwd: string | undefined;
+  config: LuciferConfig;
+  approvalChannel: ApprovalChannel;
+  pendingStore: PendingRequestStore;
+  auditLog: AuditLog;
+  aliasAudit: AliasAudit;
+  res: Response;
+}
+
+/**
+ * Handles the manual_approve branch: pending-store gating, abort-on-disconnect
+ * wiring, approval channel race with timeout, and the final execute+audit or
+ * decision-rejection response. Separated from `registerExecuteRoutes` because
+ * it dominated the route handler's line count; behaviour is unchanged.
+ */
+export async function handleManualApproval(args: ManualApprovalArgs): Promise<void> {
+  const {
+    command, requestId, apiKeyName, ip, cwd, config,
+    approvalChannel, pendingStore, auditLog, aliasAudit, res,
+  } = args;
+
+  const riskAnalysis = analyzeCommandRisk(command);
+  const abortController = new AbortController();
+
+  log.info({ requestId, command, ip }, 'Command requires manual approval, forwarding to approval channel');
+
+  // Reject an identical command from the same API key that is still
+  // awaiting an approval decision — two parallel prompts for the same
+  // command would confuse the human approver. The pendingStore entry is
+  // cleared as soon as a decision is reached (below), so this gate does
+  // NOT apply while an approved command is executing; a concurrent caller
+  // will fall through to the normal `findApproval` cached-approval path.
+  if (pendingStore.findByCommand(command, apiKeyName)) {
+    res.status(409).json({
+      code: 'DUPLICATE_IN_FLIGHT',
+      message: 'An identical command from this API key is already awaiting approval. Retry after it settles.',
+      retryable: true,
+    } satisfies ErrorResponse);
+    return;
+  }
+
+  try {
+    pendingStore.add({
+      requestId,
+      command,
+      apiKeyName,
+      ip,
+      createdAt: new Date().toISOString(),
+      resolve: () => {},
+      reject: () => {},
+      abortController,
+    });
+
+    // Abort execution if the client disconnects before we finish writing
+    // the response. `res.on('close')` fires for both premature disconnects
+    // and normal completion, so we gate on `res.writableEnded` to ignore
+    // the normal-completion case.
+    res.on('close', () => {
+      if (res.writableEnded) return;
+      abortController.abort();
+      pendingStore.remove(requestId);
+    });
+
+    const approvalResult = await Promise.race([
+      approvalChannel.requestApproval(command, apiKeyName, ip, requestId, riskAnalysis),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('Approval timed out')), config.approvalTimeoutSeconds * 1000);
+      }),
+      // Bail out of the approval wait if the client disconnected. Otherwise
+      // the handler would continue awaiting the channel until either the
+      // approver acts or the approval timeout fires — orphaning work that
+      // nobody is listening for.
+      new Promise<never>((_, reject) => {
+        if (abortController.signal.aborted) {
+          reject(new Error('Request aborted'));
+          return;
+        }
+        abortController.signal.addEventListener(
+          'abort',
+          () => reject(new Error('Request aborted')),
+          { once: true },
+        );
+      }),
+    ]);
+
+    // Approval decision obtained — release the pending-store slot now so
+    // DUPLICATE_IN_FLIGHT only gates *awaiting-approval* duplicates and
+    // not in-flight execution. `release` (unlike `remove`) does not abort
+    // the live AbortController, which still guards the upcoming execution.
+    pendingStore.release(requestId);
+
+    if (approvalResult.decision === 'denied') {
+      res.status(403).json({
+        requestId,
+        status: 'denied' as RequestStatus,
+        code: 'DENIED',
+        message: 'Command was denied',
+        retryable: false,
+      });
+      return;
+    }
+
+    await executeAndAudit({
+      command, requestId, cwd, config, auditLog, aliasAudit,
+      abortSignal: abortController.signal,
+      res,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    if (message.includes('aborted')) {
+      // Client disconnected before a decision landed. Ask the channel to
+      // clean up any bot message / admin queue entry. No response to send.
+      try { approvalChannel.cancel?.(requestId); } catch { /* best-effort */ }
+      log.info({ requestId }, 'Approval wait aborted by client disconnect');
+    } else if (message.includes('timed out')) {
+      res.status(408).json({
+        requestId,
+        status: 'timed_out' as RequestStatus,
+        code: 'APPROVAL_TIMEOUT',
+        message: 'Approval timed out. No response from approver.',
+        retryable: true,
+      });
+    } else {
+      res.status(503).json({
+        requestId,
+        code: 'APPROVAL_ERROR',
+        message: `Approval channel error: ${message}`,
+        retryable: true,
+      });
+    }
+  } finally {
+    pendingStore.remove(requestId);
+  }
+}


### PR DESCRIPTION
## Summary
- `cli.ts`: 350 → 63 lines. Subcommand bodies extracted into `server/src/cli/` (print_help, init_config, run_log, run_stats, run_pair, run_server) plus `args.ts`. `cli.ts` is now a thin dispatcher.
- `register_execute_routes.ts`: 353 → 188 lines. The three execute-and-audit branches share a new `service/execute_and_audit.ts` helper, and the manual-approve try/catch moves to `service/handle_manual_approval.ts`.
- Behaviour preserving. Audit shape, HTTP status codes, ADR-009 alias-bypass ordering, and abort-on-disconnect semantics are all unchanged.

Closes #34

## Test plan
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 329 tests passed (30 files)
- [x] \`npm run build\` — structure check + tsc clean