### PR TITLE
refactor(#30): extract rule-resolution dispatch from registerExecuteRoutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Target content for 1.0 (tracked in [`docs/quality/PRE-1.0-CHECKPOINT.md`](docs/q
 - Stabilise the public HTTP surface on `command-gateway` and `request-proxy`.
 - Lock the layered dependency direction (Types → Config → Repository → Service → Runtime → UI/API) as a hard CI invariant.
 
+## [0.8.12] — 2026-04-22
+
+### Changed
+- `server/src/domains/command-gateway/api/register_execute_routes.ts` (188 → 181 lines): extracted the rule-resolution + dispatch block into a pure helper `service/resolve_execution_plan.ts` that returns a discriminated `ExecutionPlan` union (`alias-args-bypass` / `rule-deny` / `always-approve` / `cached-approval` / `manual-approve`). The route handler switches on `plan.kind` and keeps every audit append, HTTP status/code, and the ADR-009 alias-bypass-before-rule-match ordering unchanged. Closes #30 by completing the a/b/c/d decomposition started in PR #45 (parts (a), (c), (d)); this PR is part (b). 7 focused unit tests on the pure planner bring the suite to 336 tests.
+
 ## [0.8.11] — 2026-04-22
 
 ### Changed

--- a/server/src/domains/command-gateway/api/register_execute_routes.ts
+++ b/server/src/domains/command-gateway/api/register_execute_routes.ts
@@ -8,7 +8,7 @@ import type { ApiKeyStore, CommandRulesStore, ApprovalStore, PendingRequestStore
 import { authenticateRequest, createRateLimiter } from '../service/authenticate_request.js';
 import { executeAndAudit } from '../service/execute_and_audit.js';
 import { handleManualApproval } from '../service/handle_manual_approval.js';
-import { findAliasArgsBypass, resolveAlias } from '../service/resolve_alias.js';
+import { resolveExecutionPlan } from '../service/resolve_execution_plan.js';
 
 interface ValidationError {
   statusCode: number;
@@ -106,49 +106,44 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
       ip,
     });
 
-    // Reject commands that start with an alias name but are not an exact
-    // alias invocation. Without this check, `"<alias> --arg"` or
-    // `"<alias>; rm -rf /"` would fail alias exact-match, fall through to the
-    // shell, and still be auto-approved by any prefix-based command rule that
-    // matches the alias name — shadow-bypassing the alias's shell-free
-    // execution guarantee. See ADR-009.
-    const aliasBypass = findAliasArgsBypass(command, config.aliases);
-    if (aliasBypass) {
+    const plan = resolveExecutionPlan({
+      command,
+      aliases: config.aliases,
+      commandRulesStore,
+      approvalStore,
+    });
+
+    if (plan.kind === 'alias-args-bypass') {
+      // ADR-009: reject commands that start with an alias name but are not an
+      // exact alias invocation, before any rule match runs. Without this check
+      // a prefix-based command rule on the alias name would shadow-bypass the
+      // alias's shell-free execution guarantee.
       auditLog.append({
         ts: new Date().toISOString(),
         type: 'denied',
         requestId,
         command,
-        error: `alias '${aliasBypass}' does not accept arguments`,
+        error: `alias '${plan.alias}' does not accept arguments`,
       });
       res.status(403).json({
         code: 'ALIAS_ARGS_NOT_SUPPORTED',
-        message: `Alias '${aliasBypass}' does not accept arguments in this version. Send '${aliasBypass}' exactly.`,
+        message: `Alias '${plan.alias}' does not accept arguments in this version. Send '${plan.alias}' exactly.`,
         retryable: false,
       } satisfies ErrorResponse);
       return;
     }
 
-    // Resolve the alias once up front so audit entries for rule decisions,
-    // approval checks, and execution all carry `aliasPath`/`aliasType` when
-    // the command runs as an alias. `resolveAlias` is pure and cheap; the
-    // executor does its own lookup to stay self-contained.
-    const resolvedAlias = resolveAlias(command, config.aliases);
-    const aliasAudit = resolvedAlias
-      ? { aliasPath: resolvedAlias.path, aliasType: resolvedAlias.type }
-      : {};
-
-    // Match against command rules
-    const ruleMatch = commandRulesStore.matchRule(command);
     auditLog.append({
       ts: new Date().toISOString(),
       type: 'rule_match',
       requestId,
       command,
-      ruleAction: ruleMatch.action,
+      ruleAction: plan.ruleAction,
     });
 
-    if (ruleMatch.action === 'always_deny') {
+    const { aliasAudit } = plan;
+
+    if (plan.kind === 'rule-deny') {
       auditLog.append({ ts: new Date().toISOString(), type: 'denied', requestId, command, ...aliasAudit });
       res.status(403).json({
         code: 'COMMAND_DENIED',
@@ -158,15 +153,13 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
       return;
     }
 
-    if (ruleMatch.action === 'always_approve') {
+    if (plan.kind === 'always-approve') {
       auditLog.append({ ts: new Date().toISOString(), type: 'approved', requestId, command, duration: 'policy', ...aliasAudit });
       await executeAndAudit({ command, requestId, cwd, config, auditLog, aliasAudit, res });
       return;
     }
 
-    // manual_approve: check existing approval in SQLite
-    const existingApproval = approvalStore.findApproval(command);
-    if (existingApproval) {
+    if (plan.kind === 'cached-approval') {
       auditLog.append({
         ts: new Date().toISOString(),
         type: 'approval_check',
@@ -179,7 +172,7 @@ export function registerExecuteRoutes(deps: ExecuteRouteDeps): void {
       return;
     }
 
-    // Need manual approval (Telegram / web admin)
+    // plan.kind === 'manual-approve'
     await handleManualApproval({
       command, requestId, apiKeyName, ip, cwd, config,
       approvalChannel, pendingStore, auditLog, aliasAudit, res,

--- a/server/src/domains/command-gateway/service/resolve_execution_plan.test.ts
+++ b/server/src/domains/command-gateway/service/resolve_execution_plan.test.ts
@@ -13,7 +13,11 @@ function rulesStore(action: RuleAction): CommandRulesStore {
 function approvalStore(hit: CommandApproval | undefined): ApprovalStore {
   return {
     findApproval: () => hit,
-    addApproval: () => ({ id: 1, command: '', matchType: 'exact', duration: 'session', approvedBy: 'test', approvedAt: '' }),
+    addApproval: () => ({
+      id: 1, command: '', matchType: 'exact',
+      duration: 'session', approvedBy: 'test',
+      approvedAt: '', expiresAt: null,
+    }),
     removeExpired: () => 0,
     listAll: () => [],
     revokeById: () => false,
@@ -83,7 +87,8 @@ describe('resolveExecutionPlan', () => {
   it('returns cached-approval when manual_approve matches but a cached approval exists', () => {
     const cached: CommandApproval = {
       id: 42, command: 'git push', matchType: 'exact',
-      duration: 'session', approvedBy: 'owner', approvedAt: new Date().toISOString(),
+      duration: 'session', approvedBy: 'owner',
+      approvedAt: new Date().toISOString(), expiresAt: null,
     };
     const plan = resolveExecutionPlan({
       command: 'git push',

--- a/server/src/domains/command-gateway/service/resolve_execution_plan.test.ts
+++ b/server/src/domains/command-gateway/service/resolve_execution_plan.test.ts
@@ -25,7 +25,7 @@ const emptyApprovals = approvalStore(undefined);
 describe('resolveExecutionPlan', () => {
   it('returns alias-args-bypass when a command shadows an alias with arguments', () => {
     const aliases: AliasesConfig = {
-      'deploy': { path: '/tmp/deploy.sh', type: 'bash' },
+      'deploy': { path: '/opt/bin/deploy.sh', type: 'bash' },
     };
     const plan = resolveExecutionPlan({
       command: 'deploy --force',
@@ -65,7 +65,7 @@ describe('resolveExecutionPlan', () => {
 
   it('enriches aliasAudit with path/type when the command is an exact alias invocation', () => {
     const aliases: AliasesConfig = {
-      'deploy': { path: '/tmp/deploy.sh', type: 'bash' },
+      'deploy': { path: '/opt/bin/deploy.sh', type: 'bash' },
     };
     const plan = resolveExecutionPlan({
       command: 'deploy',
@@ -106,7 +106,7 @@ describe('resolveExecutionPlan', () => {
 
   it('alias-args bypass is checked before rule match (ADR-009 ordering)', () => {
     const aliases: AliasesConfig = {
-      'ls': { path: '/tmp/ls.sh', type: 'bash' },
+      'ls': { path: '/opt/bin/ls.sh', type: 'bash' },
     };
     // Rule store would always_approve, but alias-args bypass must win first.
     const plan = resolveExecutionPlan({

--- a/server/src/domains/command-gateway/service/resolve_execution_plan.test.ts
+++ b/server/src/domains/command-gateway/service/resolve_execution_plan.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { resolveExecutionPlan } from './resolve_execution_plan.js';
+import type { ApprovalStore, CommandRulesStore } from '../types/store_interfaces.js';
+import type { AliasesConfig, CommandApproval, RuleAction } from '../types/command_types.js';
+
+function rulesStore(action: RuleAction): CommandRulesStore {
+  return {
+    matchRule: () => ({ rule: null, action }),
+    reload: () => {},
+  };
+}
+
+function approvalStore(hit: CommandApproval | undefined): ApprovalStore {
+  return {
+    findApproval: () => hit,
+    addApproval: () => ({ id: 1, command: '', matchType: 'exact', duration: 'session', approvedBy: 'test', approvedAt: '' }),
+    removeExpired: () => 0,
+    listAll: () => [],
+    revokeById: () => false,
+  };
+}
+
+const emptyApprovals = approvalStore(undefined);
+
+describe('resolveExecutionPlan', () => {
+  it('returns alias-args-bypass when a command shadows an alias with arguments', () => {
+    const aliases: AliasesConfig = {
+      'deploy': { path: '/tmp/deploy.sh', type: 'bash' },
+    };
+    const plan = resolveExecutionPlan({
+      command: 'deploy --force',
+      aliases,
+      commandRulesStore: rulesStore('always_approve'),
+      approvalStore: emptyApprovals,
+    });
+    expect(plan).toEqual({ kind: 'alias-args-bypass', alias: 'deploy' });
+  });
+
+  it('returns rule-deny when the rule action is always_deny', () => {
+    const plan = resolveExecutionPlan({
+      command: 'rm -rf /',
+      aliases: undefined,
+      commandRulesStore: rulesStore('always_deny'),
+      approvalStore: emptyApprovals,
+    });
+    expect(plan.kind).toBe('rule-deny');
+    if (plan.kind === 'rule-deny') {
+      expect(plan.ruleAction).toBe('always_deny');
+      expect(plan.aliasAudit).toEqual({});
+    }
+  });
+
+  it('returns always-approve with empty aliasAudit when no alias resolves', () => {
+    const plan = resolveExecutionPlan({
+      command: 'ls',
+      aliases: undefined,
+      commandRulesStore: rulesStore('always_approve'),
+      approvalStore: emptyApprovals,
+    });
+    expect(plan.kind).toBe('always-approve');
+    if (plan.kind === 'always-approve') {
+      expect(plan.aliasAudit).toEqual({});
+    }
+  });
+
+  it('enriches aliasAudit with path/type when the command is an exact alias invocation', () => {
+    const aliases: AliasesConfig = {
+      'deploy': { path: '/tmp/deploy.sh', type: 'bash' },
+    };
+    const plan = resolveExecutionPlan({
+      command: 'deploy',
+      aliases,
+      commandRulesStore: rulesStore('always_approve'),
+      approvalStore: emptyApprovals,
+    });
+    expect(plan.kind).toBe('always-approve');
+    if (plan.kind === 'always-approve') {
+      expect(plan.aliasAudit).toMatchObject({ aliasType: 'bash' });
+      expect((plan.aliasAudit as { aliasPath: string }).aliasPath).toContain('deploy.sh');
+    }
+  });
+
+  it('returns cached-approval when manual_approve matches but a cached approval exists', () => {
+    const cached: CommandApproval = {
+      id: 42, command: 'git push', matchType: 'exact',
+      duration: 'session', approvedBy: 'owner', approvedAt: new Date().toISOString(),
+    };
+    const plan = resolveExecutionPlan({
+      command: 'git push',
+      aliases: undefined,
+      commandRulesStore: rulesStore('manual_approve'),
+      approvalStore: approvalStore(cached),
+    });
+    expect(plan.kind).toBe('cached-approval');
+  });
+
+  it('returns manual-approve when manual_approve matches and no cached approval exists', () => {
+    const plan = resolveExecutionPlan({
+      command: 'git push',
+      aliases: undefined,
+      commandRulesStore: rulesStore('manual_approve'),
+      approvalStore: emptyApprovals,
+    });
+    expect(plan.kind).toBe('manual-approve');
+  });
+
+  it('alias-args bypass is checked before rule match (ADR-009 ordering)', () => {
+    const aliases: AliasesConfig = {
+      'ls': { path: '/tmp/ls.sh', type: 'bash' },
+    };
+    // Rule store would always_approve, but alias-args bypass must win first.
+    const plan = resolveExecutionPlan({
+      command: 'ls -la',
+      aliases,
+      commandRulesStore: rulesStore('always_approve'),
+      approvalStore: emptyApprovals,
+    });
+    expect(plan.kind).toBe('alias-args-bypass');
+  });
+});

--- a/server/src/domains/command-gateway/service/resolve_execution_plan.ts
+++ b/server/src/domains/command-gateway/service/resolve_execution_plan.ts
@@ -1,0 +1,68 @@
+import type { AliasesConfig, RuleAction } from '../types/command_types.js';
+import type { ApprovalStore, CommandRulesStore } from '../types/store_interfaces.js';
+import { findAliasArgsBypass, resolveAlias } from './resolve_alias.js';
+
+/**
+ * Decision shape the route handler acts on. Each kind is terminal: the caller
+ * inspects `kind` and performs the matching audit + HTTP response. Keeping
+ * this pure means it is straightforward to unit-test the (b) rule-resolution
+ * + risk-analysis phase of the execute pipeline in isolation (see #30).
+ */
+export type ExecutionPlan =
+  | { kind: 'alias-args-bypass'; alias: string }
+  | { kind: 'rule-deny'; aliasAudit: AliasAudit; ruleAction: RuleAction }
+  | { kind: 'always-approve'; aliasAudit: AliasAudit; ruleAction: RuleAction }
+  | { kind: 'cached-approval'; aliasAudit: AliasAudit; ruleAction: RuleAction }
+  | { kind: 'manual-approve'; aliasAudit: AliasAudit; ruleAction: RuleAction };
+
+export type AliasAudit =
+  | { aliasPath: string; aliasType: import('../types/command_types.js').AliasType }
+  | Record<string, never>;
+
+export interface ResolveExecutionPlanDeps {
+  command: string;
+  aliases: AliasesConfig | undefined;
+  commandRulesStore: CommandRulesStore;
+  approvalStore: ApprovalStore;
+}
+
+/**
+ * Pure decision function — no audit writes, no HTTP, no I/O side effects.
+ *
+ * Order of checks (invariant; ADR-009):
+ *  1. Alias-args bypass detection — reject commands that look like alias
+ *     invocations with arguments so they never fall through to a rule match.
+ *  2. Alias resolution for audit enrichment.
+ *  3. Command-rule match → deny / always-approve / manual-approve branch.
+ *  4. For `manual_approve`, probe the approval store for an existing cached
+ *     approval before asking a human.
+ */
+export function resolveExecutionPlan(deps: ResolveExecutionPlanDeps): ExecutionPlan {
+  const { command, aliases, commandRulesStore, approvalStore } = deps;
+
+  const aliasBypass = findAliasArgsBypass(command, aliases);
+  if (aliasBypass) {
+    return { kind: 'alias-args-bypass', alias: aliasBypass };
+  }
+
+  const resolved = resolveAlias(command, aliases);
+  const aliasAudit: AliasAudit = resolved
+    ? { aliasPath: resolved.path, aliasType: resolved.type }
+    : {};
+
+  const ruleMatch = commandRulesStore.matchRule(command);
+  const ruleAction = ruleMatch.action;
+
+  if (ruleAction === 'always_deny') {
+    return { kind: 'rule-deny', aliasAudit, ruleAction };
+  }
+  if (ruleAction === 'always_approve') {
+    return { kind: 'always-approve', aliasAudit, ruleAction };
+  }
+
+  // manual_approve — check cached approval first.
+  if (approvalStore.findApproval(command)) {
+    return { kind: 'cached-approval', aliasAudit, ruleAction };
+  }
+  return { kind: 'manual-approve', aliasAudit, ruleAction };
+}

--- a/server/src/domains/command-gateway/service/resolve_execution_plan.ts
+++ b/server/src/domains/command-gateway/service/resolve_execution_plan.ts
@@ -1,23 +1,27 @@
-import type { AliasesConfig, RuleAction } from '../types/command_types.js';
+import type { AliasesConfig } from '../types/command_types.js';
 import type { ApprovalStore, CommandRulesStore } from '../types/store_interfaces.js';
 import { findAliasArgsBypass, resolveAlias } from './resolve_alias.js';
+import type { AliasAudit } from './execute_and_audit.js';
+
+export type { AliasAudit };
 
 /**
  * Decision shape the route handler acts on. Each kind is terminal: the caller
  * inspects `kind` and performs the matching audit + HTTP response. Keeping
- * this pure means it is straightforward to unit-test the (b) rule-resolution
- * + risk-analysis phase of the execute pipeline in isolation (see #30).
+ * this as a pure decision function means the (b) rule-resolution +
+ * risk-analysis phase of the execute pipeline (see #30) is unit-testable in
+ * isolation.
+ *
+ * Per-variant `ruleAction` is the specific literal produced by the check
+ * that selected that variant, so a `kind: 'always-approve'` plan cannot
+ * carry `ruleAction: 'always_deny'`.
  */
 export type ExecutionPlan =
   | { kind: 'alias-args-bypass'; alias: string }
-  | { kind: 'rule-deny'; aliasAudit: AliasAudit; ruleAction: RuleAction }
-  | { kind: 'always-approve'; aliasAudit: AliasAudit; ruleAction: RuleAction }
-  | { kind: 'cached-approval'; aliasAudit: AliasAudit; ruleAction: RuleAction }
-  | { kind: 'manual-approve'; aliasAudit: AliasAudit; ruleAction: RuleAction };
-
-export type AliasAudit =
-  | { aliasPath: string; aliasType: import('../types/command_types.js').AliasType }
-  | Record<string, never>;
+  | { kind: 'rule-deny'; aliasAudit: AliasAudit; ruleAction: 'always_deny' }
+  | { kind: 'always-approve'; aliasAudit: AliasAudit; ruleAction: 'always_approve' }
+  | { kind: 'cached-approval'; aliasAudit: AliasAudit; ruleAction: 'manual_approve' }
+  | { kind: 'manual-approve'; aliasAudit: AliasAudit; ruleAction: 'manual_approve' };
 
 export interface ResolveExecutionPlanDeps {
   command: string;
@@ -27,7 +31,11 @@ export interface ResolveExecutionPlanDeps {
 }
 
 /**
- * Pure decision function — no audit writes, no HTTP, no I/O side effects.
+ * Pure decision function — no audit writes, no HTTP response, no filesystem
+ * or network I/O. It does read from the injected rule/approval stores
+ * (which may perform their own lookup, e.g. SQLite `findApproval`), but
+ * the function itself is side-effect-free relative to the execute
+ * pipeline: it produces a decision and returns.
  *
  * Order of checks (invariant; ADR-009):
  *  1. Alias-args bypass detection — reject commands that look like alias


### PR DESCRIPTION
## Summary
- Completes the a/b/c/d decomposition of `registerExecuteRoutes` from #30. Parts (a), (c), (d) shipped in PR #45 (0.8.10); this PR is part (b): rule-resolution + risk-analysis.
- Extracts the alias-bypass + alias-resolution + rule-match + cached-approval dispatch block into a new pure helper `service/resolve_execution_plan.ts` that returns a discriminated `ExecutionPlan` union (`alias-args-bypass` / `rule-deny` / `always-approve` / `cached-approval` / `manual-approve`). No `auditLog`, no `res`, no I/O.
- The route handler switches on `plan.kind` and performs the same audit appends and HTTP responses as before — every audit entry, HTTP status/code, and the ADR-009 alias-bypass-before-rule-match ordering are structurally identical to the pre-refactor code.
- `register_execute_routes.ts`: 188 → 181 lines. The line-count win is modest because the route handler still owns every side effect per `plan.kind`; the real win is that the decision logic is now pure and directly unit-testable.
- Changelog entry added under `[0.8.12]`.

Closes #30

## Plan
https://github.com/alkampfergit/lucifer/issues/30#issuecomment-4295778619

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 31 files / **336 tests pass** (329 prior + 7 new `resolve_execution_plan` unit tests covering: ADR-009 ordering, `always_deny`, `always_approve` with/without alias, `manual_approve` cached vs uncached)
- [x] `npm run build` — dependency-structure check + `tsc` pass

### Note on the ≤100-line target

The plan targeted `register_execute_routes.ts ≤ 100 lines`; the actual result is 181. Hitting 100 would require hoisting each `plan.kind` arm into its own handler helper, which trades the current single-file read for more indirection. Happy to do that pass if you prefer — flag it on this PR.
